### PR TITLE
Fix the Issue #28

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -142,7 +142,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         if ($conn->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $this->sequenceWorkspaceName = 'phpcr_workspaces_id_seq';
             $this->sequenceNodeName = 'phpcr_nodes_id_seq';
-            $this->sequenceTypeName = 'phpcr_type_nodes_id_seq';
+            $this->sequenceTypeName = 'phpcr_type_nodes_node_type_id_seq';
         }
         $this->cache = $cache ?: new ArrayCache();
     }


### PR DESCRIPTION
as postgresql name sequences based on related culomn name,
the proper sequence name for `phpcr_type_nodes` table is `phpcr_type_nodes_node_type_id_seq`

in general, specifying the sequence name manually would be much better :)
