### PR TITLE
Implementation of the NodeType constraints validations

### DIFF
--- a/tests/inc/DoctrineDBALImplementationLoader.php
+++ b/tests/inc/DoctrineDBALImplementationLoader.php
@@ -52,9 +52,6 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     // https://github.com/phpcr/phpcr-api-tests/issues/22
                     'Query\\NodeViewTest::testSeekable',
 
-                    //TODO: remove after checks finalized with NodeType and canSetProperty method
-                    'Writing\\AddMethodsTest::testAddPropertyWrongType', //TODO: https://github.com/jackalope/jackalope-doctrine-dbal/issues/18
-
                     'Writing\\CopyMethodsTest::testCopyUpdateOnCopy', //TODO: update-on-copy is currently not supported
                     'Writing\\CopyMethodsTest::testWorkspaceCopy', //TODO: https://github.com/jackalope/jackalope-doctrine-dbal/issues/19
                     'Writing\\DeleteMethodsTest::testNodeRemovePropertyConstraintViolation', //TODO: https://github.com/jackalope/jackalope-doctrine-dbal/issues/34


### PR DESCRIPTION
Thanks to the refactoring on Jackalope made to allow the NodeType constraints validations, a few previously skipped tests can now be run successfully. 

The following pull request needs to be merged first: https://github.com/jackalope/jackalope/pull/123
