### PR TITLE
[WIP] We need to be able to denote an empty array as the cached value

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -124,7 +124,7 @@ class CachedClient extends Client
     {
         $this->assertLoggedIn();
 
-        if (isset($this->caches['nodes']) && $result = $this->caches['nodes']->fetch("nodes: $path, ".$this->workspaceId)) {
+        if (isset($this->caches['nodes']) && (false !== ($result = $this->caches['nodes']->fetch("nodes: $path, ".$this->workspaceId)))) {
             return $result;
         }
 
@@ -226,7 +226,7 @@ class CachedClient extends Client
     {
         $this->assertLoggedIn();
 
-        if (isset($this->caches['nodes']) && $result = $this->caches['nodes']->fetch("nodes by uuid: $uuid, ".$this->workspaceId)) {
+        if (isset($this->caches['nodes']) && (false !== ($result = $this->caches['nodes']->fetch("nodes by uuid: $uuid, ".$this->workspaceId)))) {
             return $result;
         }
 
@@ -298,7 +298,7 @@ class CachedClient extends Client
      */
     protected function getNodeReferences($path, $name = null, $weakReference = false)
     {
-        if (isset($this->caches['nodes']) && $result = $this->caches['nodes']->fetch("nodes references: $path, $name, $weakReference, ".$this->workspaceId)) {
+        if (isset($this->caches['nodes']) && (false !== ($result = $this->caches['nodes']->fetch("nodes references: $path, $name, $weakReference, ".$this->workspaceId)))) {
             return $result;
         }
 


### PR DESCRIPTION
On a site with 200 pages, I still have 400 unnecessary queries per page (down from 3000 earlier today - thanks @lsmith77!)

This seems to be because each content node generates a call to [`Client::getReferences`](https://github.com/jackalope/jackalope-doctrine-dbal/blob/master/src/Jackalope/Transport/DoctrineDBAL/Client.php#L1875)  and this does two queries (via [`Client::getNodeReferences`](https://github.com/jackalope/jackalope-doctrine-dbal/blob/master/src/Jackalope/Transport/DoctrineDBAL/Client.php#L1895)) and then returns an empty array.

From what I can see, the cache cant save an empty array, so if the queried result is an empty array then it gets re-queried on every page request.

Doing something like I have done in this commit - i.e. somehow denoting the empty array in a format in which it can be cached - removes all superflous queries once the cache is full. So now down to zero(!) cmf queries.

Obviously just using the text 'empty' is no good - but it demonstrates the sort of solution I think is needed.

Any thoughts on how we should do this "properly", if indeed this is confirmed as the source of the problem.
