### PR TITLE
Use $xpath->evaluate instead of $xpath->query

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -151,7 +151,11 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
             $dom = new \DOMDocument('1.0', 'UTF-8');
             $dom->loadXML($string);
             $xpath = new \DOMXPath($dom);
-            $list = $xpath->query($expression);
+            $list = $xpath->evaluate($expression);
+
+            if (!is_object($list)) {
+                return $list;
+            }
 
             // @TODO: don't know if there are expressions returning more then one row
             if ($list->length > 0) {


### PR DESCRIPTION
The results of `$xpath->query()` are always expected to be a Node list. However, some of the only (the only?) uses of `EXTRACTVALUE` were to evaluate `count()` expressions. Those will never return
a Node list. So `evaluate()` is used instead. If something that is not an object is returned, we return that immediately. Otherwise we assume it is a Node list.

Maybe this is an incorrect assumption but we can hopefully address that when that comes up.

Test to ensure that walker returns expected SQL.

Initial discussion on implementation:
- https://gist.github.com/8a79193b743287ed11e3
