### PR TITLE
WIP Children and Properties with the same name

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -828,19 +828,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         $nodeData = array();
 
         foreach ($rows as $row) {
-            if ($row['path'] == $path) {
-                $node = $this->getNodeData($path, $row);
-            } else {
-                $pathDiff = ltrim(substr($row['path'], strlen($path)),'/');
-                $nodeData[$pathDiff] = $this->getNodeData($row['path'], $row);
-            }
+            $nodeData[$row['path']] = $this->getNodeData($row['path'], $row);
         }
-
-        foreach ($nodeData as $key => $value) {
-            $node->{$key} = $value;
-        }
-
-        return $node;
+        return $nodeData;
     }
 
     private function getNodeData($path, $row)
@@ -960,9 +950,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         $all = $stmt->fetchAll(\PDO::FETCH_UNIQUE | \PDO::FETCH_GROUP);
 
         $nodes = array();
-        foreach ($paths as $key => $path) {
+        foreach ($paths as $path) {
             if (isset($all[$path])) {
-                $nodes[$key] = $this->getNodeData($path, $all[$path]);
+                $nodes[$path] = $this->getNodeData($path, $all[$path]);
             }
         }
 


### PR DESCRIPTION
Implementing this feature requires changes to Jackalope and I think a significant BC break, because returning data to Jackalopes `ObjectManager::getNodeByPath` [as the tree it currently expects](https://github.com/jackalope/jackalope/blob/master/src/Jackalope/ObjectManager.php#L207), lets children overwrite same name properties.

This WIP is for the changes we might need to make to this transport  - returning all results as elements of a single array to avoid one overwriting the other.
