### PR TITLE
split the references into 2 tables to allow using defered FKs in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+* **2013-06-07**: [#75] split the references into 2 tables
+ * This splits the phpcr_nodes_foreignkeys into two separate tables
+ * Improves performance and allows using native deferred FK capabilities in the future
+ * Migration steps
+   * run ``bin/jackalope jackalope:init:dbal --dump-sql``
+   * Copy and execute all tables, indexes etc related to ``phpcr_nodes_references`` and ``phpcr_nodes_weakreferences``.
+   * Run the following SQL statements:
+     * INSERT INTO phpcr_nodes_references ( source_id, source_property_name, target_id )
+       SELECT source_id, source_property_name, target_id FROM phpcr_nodes_foreignkeys WHERE type = 9;
+     * INSERT INTO phpcr_nodes_weakreferences ( source_id, source_property_name, target_id )
+       SELECT source_id, source_property_name, target_id FROM phpcr_nodes_foreignkeys WHERE type = 10;
+     * DROP TABLE phpcr_nodes_foreignkeys;
+
 * **2013-06-01**: [#109] ensure data is stored as UTC and returned in the default TZ
  * This enables consistent search query behavior regardless of the timezone used
  * Any existing stored nodes need to be modified, so that they are stored again

--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -58,14 +58,24 @@ class RepositorySchema
         $binary->setPrimaryKey(array('id'));
         $binary->addUniqueIndex(array('node_id', 'property_name', 'workspace_name', 'idx'));
 
-        $foreignKeys = $schema->createTable('phpcr_nodes_foreignkeys');
-        $foreignKeys->addColumn('source_id', 'integer');
-        $foreignKeys->addColumn('source_property_name', 'string', array('length' => 220));
-        $foreignKeys->addColumn('target_id', 'integer');
-        $foreignKeys->addColumn('type', 'smallint');
-        $foreignKeys->setPrimaryKey(array('source_id', 'source_property_name', 'target_id'));
-        $foreignKeys->addIndex(array('target_id'));
-        $foreignKeys->addForeignKeyConstraint($nodes, array('source_id'), array('id'), array('onDelete' => 'CASCADE'));
+        $references = $schema->createTable('phpcr_nodes_references');
+        $references->addColumn('source_id', 'integer');
+        $references->addColumn('source_property_name', 'string', array('length' => 220));
+        $references->addColumn('target_id', 'integer');
+        $references->setPrimaryKey(array('source_id', 'source_property_name', 'target_id'));
+        $references->addIndex(array('target_id'));
+        $references->addForeignKeyConstraint($nodes, array('source_id'), array('id'), array('onDelete' => 'CASCADE'));
+        // TODO: this should be reenabled on RDBMS with deferred FK support
+        //$references->addForeignKeyConstraint($nodes, array('target_id'), array('id'));
+
+        $weakreferences = $schema->createTable('phpcr_nodes_weakreferences');
+        $weakreferences->addColumn('source_id', 'integer');
+        $weakreferences->addColumn('source_property_name', 'string', array('length' => 220));
+        $weakreferences->addColumn('target_id', 'integer');
+        $weakreferences->setPrimaryKey(array('source_id', 'source_property_name', 'target_id'));
+        $weakreferences->addIndex(array('target_id'));
+        $weakreferences->addForeignKeyConstraint($nodes, array('source_id'), array('id'), array('onDelete' => 'CASCADE'));
+        $weakreferences->addForeignKeyConstraint($nodes, array('target_id'), array('id'), array('onDelete' => 'CASCADE'));
 
         $types = $schema->createTable('phpcr_type_nodes');
         $types->addColumn('node_type_id', 'integer', array('autoincrement' => true));

--- a/tests/generate_fixtures.php
+++ b/tests/generate_fixtures.php
@@ -24,7 +24,7 @@ function generate_fixtures($srcDir, $destDir)
         $destDom->addNamespaces($srcDom->getNamespaces());
         $destDom->addNodes('tests', $nodes);
         // delay this to the end to not add entries for weak refs to not existing nodes
-        $destDom->addForeignKeys();
+        $destDom->addReferences();
         $destDom->save();
     }
 }


### PR DESCRIPTION
Upgrade steps:
Upgrade jackalope/jackalope-doctrine-dbal
Run `app/console doctrine:phpcr:init:dbal --dump-sql`
Copy and execute all tables, indexes etc related to `phpcr_nodes_references` and `phpcr_nodes_weakreferences`.

Run the following SQL statements:
INSERT INTO phpcr_nodes_references ( source_id, source_property_name, target_id )
SELECT source_id, source_property_name, target_id
FROM phpcr_nodes_foreignkeys WHERE type = 9;
INSERT INTO phpcr_nodes_weakreferences ( source_id, source_property_name, target_id )
SELECT source_id, source_property_name, target_id
FROM phpcr_nodes_foreignkeys WHERE type = 10;

Finally clean up the old table:
DROP TABLE phpcr_nodes_foreignkeys;

In the future we can now implement the deferred FK support:
Doctrine DBAL supports this for PostgreSQL, it should be possible to add this to SQLite as well:
https://github.com/doctrine/dbal/pull/220

http://www.postgresql.org/docs/9.2/static/sql-set-constraints.html
http://www.sqlite.org/foreignkeys.html#fk_deferred
