### PR TITLE
Check the actual error being thrown

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -202,8 +202,12 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
         try {
             $this->conn->insert('phpcr_workspaces', array('name' => $name));
-        } catch (\Exception $e) {
-            throw new RepositoryException("Workspace '$name' already exists");
+        } catch (DBALException $e) {
+            if ($e->getPrevious()->getCode() == 23000) {
+                throw new RepositoryException("Workspace '$name' already exists");
+            } else {
+                throw $e;
+            }
         }
 
         $this->conn->insert('phpcr_nodes', array(


### PR DESCRIPTION
When I first tried to create the workspace, the table didn't exist yet, but since any exception is caught and not cheked, I got the error that the workspace already existed
