### PR TITLE
Dirty fix for issue with parent constraint

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -232,7 +232,7 @@ class QOMWalker
      */
     public function walkChildNodeConstraint(QOM\ChildNodeInterface $constraint)
     {
-        return $this->getTableAlias($constraint->getSelectorName()) . ".parent = '" . $constraint->getParentPath() . "'";
+        return $this->getTableAlias($constraint->getSelectorName()) . ".parent = " . $constraint->getParentPath();
     }
 
     /**


### PR DESCRIPTION
This fixes the problems with the failing doctrine_dbal tests, however I'm pretty sure that other things are broken here (e.g. the same problem should happen with walkDescendentNodeConstraint)

The issue is that `$contraint->getParentPath` returns `"/functional/"` (i.e. it returns the double quotation marks in addition to /functional/). I think this would be an issue with `Sql2ToQomConverter`, in that it retains the quotation marks. However this works for the jackrabbit transport.

So where is the fault? Should `Sql2ToQomConverter` retain the quaotation marks, or should jackalope/doctrine-dbal remove them?
