### PR TITLE
Allow multiple properties on a node type

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1574,10 +1574,10 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                 'primary_item' => $type->getPrimaryItemName(),
             ));
 
+            $nodeTypeId = $this->conn->lastInsertId($this->sequenceTypeName);
+
             if ($propDefs = $type->getDeclaredPropertyDefinitions()) {
                 foreach ($propDefs as $propertyDef) {
-                    $nodeTypeId = $this->conn->lastInsertId($this->sequenceTypeName);
-
                     /* @var $propertyDef \Jackalope\NodeType\PropertyDefinition */
                     $this->conn->insert('phpcr_type_props', array(
                         'node_type_id' => $nodeTypeId,

--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -91,7 +91,7 @@ class RepositorySchema
         $propTypes->addColumn('required_type', 'integer');
         $propTypes->addColumn('query_operators', 'integer'); // BITMASK
         $propTypes->addColumn('default_value', 'string', array('notnull' => false));
-        $propTypes->setPrimaryKey(array('node_type_id'));
+        $propTypes->setPrimaryKey(array('node_type_id', 'name'));
 
         $childTypes = $schema->createTable('phpcr_type_childs');
         $childTypes->addColumn('node_type_id', 'integer');


### PR DESCRIPTION
The `phpcr_type_prop` table has only one key, the `node_type_id`, which prevents multiples. This PR adds `name` as PK also.
