### PR TITLE
Client::getNodes() should return array of nodes, indexed by path

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -943,9 +943,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         $all = $stmt->fetchAll(\PDO::FETCH_UNIQUE | \PDO::FETCH_GROUP);
 
         $nodes = array();
-        foreach ($paths as $key => $path) {
+        foreach ($paths as $path) {
             if (isset($all[$path])) {
-                $nodes[$key] = $this->getNodeData($path, $all[$path]);
+                $nodes[$path] = $this->getNodeData($path, $all[$path]);
             }
         }
 


### PR DESCRIPTION
This tweak fixes one of the three test failures I currently get on master for mysql.

Jackalope ObjectManager::getNodesByPath expects nodes to be returned from the transport with the node array indexed with the fetchPath. 

The key that was being used before as the returned node array index was kind of arbitrary as I don't think we specify what it should be - just that the requested paths array is an array of string paths.
