### PR TITLE
adjust to refactoring in reordering handling and simplify reorders

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1254,9 +1254,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
         $i = 0;
 
-        foreach ($node->getNodeNames() as $order => $name) {
+        foreach ($node->getNodeNames() as $name) {
             $values[':name' . $i] = $name;
-            $values[':order' . $i] = $order;
+            $values[':order' . $i] = $i; // use our counter to avoid gaps
             $sql .= " WHEN :name" . $i . " THEN :order" . $i;
             $i++;
         }


### PR DESCRIPTION
requires jackalope/jackalope#147

i simplified the method a lot. there will be more write operations now, but on the other hand we avoid a pointless read operation that would be expensive with a large node set too.

the tests of chapter 23 take the same time and memory consumption with both variants on my machine.
