### PR TITLE
Sanitization "out of range" strings

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -315,6 +315,18 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     }
 
     /**
+     * Remove characters which will cause DOMDocument to fail when parsing
+     * the XML string, for example the hex characters 00 01 02 03 etc.
+     *
+     * See: http://stackoverflow.com/questions/1401317/remove-non-utf8-characters-from-string
+     */
+    protected function sanitizeString($string)
+    {
+        $string = preg_replace('/[^(\x20-\x7F)]*/','', $string);
+        return $string;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getRepositoryDescriptors()
@@ -769,7 +781,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                 case PropertyType::URI:
                 case PropertyType::PATH:
                 case PropertyType::STRING:
-                    $values = $property->getString();
+                    $values = $this->sanitizeString($property->getString());
                     break;
                 case PropertyType::DECIMAL:
                     $values = $property->getDecimal();

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -52,6 +52,24 @@ class ClientTest extends TestCase
         $this->session = $this->repository->login(new \PHPCR\SimpleCredentials("user", "passwd"), $GLOBALS['phpcr.workspace']);
     }
 
+    public function testOutOfRangeCharacters()
+    {
+        $invalidString = urldecode('%01%02%03%00');
+
+        // if this is 1 then there isn't a problem
+        $this->assertEquals(4, strlen($invalidString));
+
+        $root = $this->session->getNode('/');
+        $article = $root->addNode('article');
+        $article->setProperty('test', $invalidString);
+        $this->session->save();
+
+        $node = $this->session->getNode('/article');
+
+        $prop = $node->getProperty('test');
+        $this->assertEquals('', $prop->getValue());
+    }
+
     public function testQueryNodes()
     {
         $root = $this->session->getNode('/');


### PR DESCRIPTION
Some strings siuch as one generated by `$invalidString = urldecode('%00%01%02');` will cause the generated XML properties document to be invalid. This PR fixes that.

I thought about adding this as a `phpcr-api-test` but wasn't quite sure how that would fit in. `10_Writing/AddMethodTests` but then this would be an "Add" then "Read" test. So, have just added a test for doctrine-dbal.
