### PR TITLE
fix searching by node name by only storing the namespace alias.

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -531,12 +531,11 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         }
 
         $namespaces = $this->getNamespaces();
-
         if (!isset($namespaces[$alias])) {
             throw new NamespaceException('the namespace ' . $alias . ' was not registered.');
         }
 
-        return array($namespaces[$alias], $name);
+        return array($alias, $name);
     }
 
     /**
@@ -567,7 +566,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         }
 
         if ($isNewNode) {
-            list($namespace, $localName) = $this->getJcrName($path);
+            list($namespaceAlias, $localName) = $this->getJcrName($path);
 
             $qb = $this->conn->createQueryBuilder();
 
@@ -584,9 +583,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                     'type'          => $type,
                     'path'          => $path,
                     'local_name'    => $localName,
-                    'namespace'     => $namespace,
+                    'namespace'     => $namespaceAlias,
                     'parent'        => PathHelper::getParentPath($path),
-                    'workspace_name'  => $this->workspaceName,
+                    'workspace_name'=> $this->workspaceName,
                     'props'         => $propsData['dom']->saveXML(),
                     'depth'         => PathHelper::getPathDepth($path),
                     'parent_a'      => PathHelper::getParentPath($path),


### PR DESCRIPTION
previously we stored the entire URL, without this change the search tests fails to find any nodes.
i guess this is what the following code was trying to deal with:
https://github.com/jackalope/jackalope-doctrine-dbal/pull/134/files#L0L584

the issue is caused by:
https://github.com/jackalope/jackalope-doctrine-dbal/blob/master/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php#L507

which results in the following to be added to the query:

```
n0.namespace || (
      CASE n0.namespace WHEN '' THEN '' ELSE ':' END
    ) || n0.local_name = 'phpcr_locale:en'
```

i guess with this change we would then somehow need to expand to an URL when we read back out of the DB? furthermore do we then risk some inconsistencies? i guess the alias needs to be unique?

/cc @dbu @wjzijderveld
