### PR TITLE
Check for invalid characters in Documents

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1678,10 +1678,10 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                 break;
             case PropertyType::DECIMAL:
             case PropertyType::STRING:
-                $values = ($property->isMultiple()) ? $property->getValue() : array($property->getValue());
-                foreach($values as $value){
+                $values = (array) $property->getValue();
+                foreach ($values as $value) {
                     if (!$this->isStringValid($value)) {
-                        throw new ValueFormatException('Invalid character found in property "'.$property->getName().'". Are you passing in valid XML string?');
+                        throw new ValueFormatException('Invalid character found in property "'.$property->getName().'". Are you passing a valid XML string?');
                     }
                 }
                 break;   
@@ -2301,8 +2301,8 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     protected function isStringValid($string)
     {
-        $regex = '/[^\x9\xa\xd\x20-\xD7FF\xE000-\xFFFD]+/x';
+        $regex = '/[^\x{9}\x{a}\x{d}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u';
 
-        return (preg_match($regex, $string) === 0);
+        return (preg_match($regex, $string, $matches) === 0);
     }
 }

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -215,14 +215,40 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @expectedException \PHPCR\ValueFormatException
+     * @dataProvider provideTestOutOfRangeCharacters
      */
-    public function testOutOfRangeCharacterOccurence()
+    public function testOutOfRangeCharacterOccurence($string, $isValid)
     {
-        $invalidString = urldecode('%01%02%03%00');
+        if (false === $isValid) {
+            $this->setExpectedException('PHPCR\ValueFormatException', 'Invalid character found in property "test". Are you passing a valid XML string?');
+        }
+
         $root = $this->session->getNode('/');
         $article = $root->addNode('article');
-        $article->setProperty('test', $invalidString);
+        $article->setProperty('test', $string);
         $this->session->save();
+    }
+
+    public function provideTestOutOfRangeCharacters()
+    {
+        return array(
+            array('This is valid too!'.$this->translateCharFromCode('\u0009'), true),
+            array('This is valid', true),
+            array($this->translateCharFromCode('\uD7FF'), true),
+            array('This is on the edge, but valid too.'. $this->translateCharFromCode('\uFFFD'), true),
+            array($this->translateCharFromCode('\u10000'), true),
+            array($this->translateCharFromCode('\u10FFFF'), true),
+            array($this->translateCharFromCode('\u0001'), false),
+            array($this->translateCharFromCode('\u0002'), false),
+            array($this->translateCharFromCode('\u0003'), false),
+            array($this->translateCharFromCode('\u0008'), false),
+            array($this->translateCharFromCode('\uFFFF'), false),
+
+        );
+    }
+
+    private function translateCharFromCode($char)
+    {
+        return json_decode('"'.$char.'"');
     }
 }


### PR DESCRIPTION
I've tried to implement check, that should throw a PHPCR\ValueFormatException, when some dangerous <control> sign occurs in document, that should be saved in a repository.

This as alternative version, how to implement this PR: https://github.com/jackalope/jackalope-doctrine-dbal/pull/99

I hope I haven't messed it up too much, this is my first PR ever..
