### PR TITLE
Added test to ensure that we can delete more than 1000 nodes.

### DIFF
--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -4,6 +4,7 @@ namespace Jackalope\Transport\DoctrineDBAL;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Jackalope\Test\TestCase;
+use PHPCR\Util\NodeHelper;
 
 class ClientTest extends TestCase
 {
@@ -251,5 +252,23 @@ class ClientTest extends TestCase
     private function translateCharFromCode($char)
     {
         return json_decode('"'.$char.'"');
+    }
+
+    public function testDeleteMoreThanOneThousandNodes()
+    {
+        $session = $this->session;
+        $nodes = array();
+        $root = $this->session->getNode('/');
+        $parent = $root->addNode('test-more-than-one-thousand');
+
+        for ($i = 0; $i <= 1200; $i++) {
+            $nodes[] = $parent->addNode('node-'.$i);
+        }
+
+        $this->session->save();
+
+        NodeHelper::purgeWorkspace($this->session);
+
+        $this->session->save();
     }
 }


### PR DESCRIPTION
In sqlite there is a hard limit to the number of records which can be
selected with the "IN(x, x, x ...)" syntax which previously caused
operations like this to fail.

This seems however to work.
