### PR TITLE
Unset nodeIdentifier on Delete

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1211,6 +1211,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         try {
             $query = 'DELETE FROM phpcr_nodes WHERE (path = ? OR path LIKE ?) AND workspace_name = ?';
             $this->conn->executeUpdate($query, $params);
+            unset($this->nodeIdentifiers[$path]);
         } catch (DBALException $e) {
             throw new RepositoryException('Unexpected exception while deleting node ' . $path, $e->getCode(), $e);
         }


### PR DESCRIPTION
I am not completely sure this is an actual bug and if so, if this is the correct fix. But it works for me ;-)

The bug I ran into can be reproduced like this:
1. Use an existing workspace
2. Delete a node from it (that has a jcr:uuid)
3. `$session->save()`
4. Recreate the node with a new reference
5. `$session->save()`
6. Use that node as reference for another (new) node

You will now get an `PHPCR\ReferentialIntegrityException`, stating that the reference you gave the does not exist.
That failed because Client.php holds an internal list of UUID's and found the UUID for the deleted Node there.
