### PR TITLE
prevent storing node types with the same name as a built-in type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* **2014-01-08**: You now get a RepositoryException if you try to overwrite one
+  of the built-in node types. In 1.0, you got no exception but the custom type
+  with the same name as a built-in type was simply ignored.
+
 * **2014-01-07**: We now properly support LENGTH in queries. This required a
   change to the stored data. To update existing installations, you can use this
   migration: https://github.com/wjzijderveld/jackalope-doctrine-dbal-length-migration

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1808,16 +1808,12 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     public function getNodeTypes($nodeTypes = array())
     {
-        $standardTypes = array();
-        foreach (StandardNodeTypes::getNodeTypeData() as $nodeTypeData) {
-            $standardTypes[$nodeTypeData['name']] = $nodeTypeData;
-        }
+        $standardTypes = StandardNodeTypes::getNodeTypeData();
 
         $userTypes = $this->fetchUserNodeTypes();
 
         if ($nodeTypes) {
             $nodeTypes = array_flip($nodeTypes);
-            // TODO: check if user types can override standard types.
             return array_values(array_intersect_key($standardTypes, $nodeTypes) + array_intersect_key($userTypes, $nodeTypes));
         }
 
@@ -1901,8 +1897,13 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     public function registerNodeTypes($types, $allowUpdate)
     {
+        $builtinTypes = StandardNodeTypes::getNodeTypeData();
+
+        /* @var $type NodeTypeDefinition */
         foreach ($types as $type) {
-            /* @var $type NodeTypeDefinition */
+            if (isset($builtinTypes[$type->getName()])) {
+                throw new RepositoryException(sprintf('%s: can\'t reregister built-in node type.', $type->getName()));
+            }
 
             if ($allowUpdate) {
                 $query = "SELECT * FROM phpcr_type_nodes WHERE name = ?";


### PR DESCRIPTION
fix #107, adjust to https://github.com/phpcr/phpcr-api-tests/pull/126
