### PR TITLE
fix repository factory parameter validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "doctrine/dbal": "~2.4",
-        "phpcr/phpcr": "~2.1.0",
+        "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "~1.2",
         "jackalope/jackalope": "~1.2.0"
     },

--- a/src/Jackalope/RepositoryFactoryDoctrineDBAL.php
+++ b/src/Jackalope/RepositoryFactoryDoctrineDBAL.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope;
 
+use PHPCR\ConfigurationException;
 use PHPCR\RepositoryFactoryInterface;
 
 /**
@@ -62,17 +63,15 @@ class RepositoryFactoryDoctrineDBAL implements RepositoryFactoryInterface
     public function getRepository(array $parameters = null)
     {
         if (null === $parameters) {
-            return null;
+            throw new ConfigurationException('Jackalope-doctrine-dbal needs parameters');
         }
 
-        // check if we have all required keys
-        $present = array_intersect_key(self::$required, $parameters);
-        if (count(array_diff_key(self::$required, $present))) {
-            return null;
+        if (count(array_diff_key(self::$required, $parameters))) {
+            throw new ConfigurationException('A required parameter is missing: ' . implode(', ', array_keys(array_diff_key(self::$required, $parameters))));
         }
-        $defined = array_intersect_key(array_merge(self::$required, self::$optional), $parameters);
-        if (count(array_diff_key($defined, $parameters))) {
-            return null;
+
+        if (count(array_diff_key($parameters, self::$required, self::$optional))) {
+            throw new ConfigurationException('Additional unknown parameters found: ' . implode(', ', array_keys(array_diff_key($parameters, self::$required, self::$optional))));
         }
 
         if (isset($parameters['jackalope.factory'])) {

--- a/tests/Jackalope/RepositoryFactoryDoctrineDBALTest.php
+++ b/tests/Jackalope/RepositoryFactoryDoctrineDBALTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jackalope;
+
+class RepositoryFactoryDoctrineDBALTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \PHPCR\ConfigurationException
+     * @expectedExceptionMessage missing
+     */
+    public function testMissingRequired()
+    {
+        $factory = new RepositoryFactoryDoctrineDBAL();
+        $factory->getRepository(array());
+    }
+
+    /**
+     * @expectedException \PHPCR\ConfigurationException
+     * @expectedExceptionMessage unknown
+     */
+    public function testExtraParameter()
+    {
+        $factory = new RepositoryFactoryDoctrineDBAL();
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->assertNull($factory->getRepository(array(
+            'jackalope.doctrine_dbal_connection' => $conn,
+            'unknown' => 'garbage',
+        )));
+    }
+}


### PR DESCRIPTION
we got the parameter validation code wrong. this PR fixes the validation and adds some tests for the error conditions.

there is a slight BC break here, in that we previously ignored unknown parameters and now detect them.

what is really user unfriendly is that the PHPCR spec says to return null if the parameters are not known. an exception would be a lot more helpful. i am tempted to violate the api doc and throw an exception.

see also https://github.com/jackalope/jackalope-jackrabbit/pull/72
