### PR TITLE
Modified unique constraint for identifier

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -96,7 +96,7 @@ class RepositorySchema extends Schema
         $nodes->addColumn('sort_order', 'integer', array('notnull' => false));
         $nodes->setPrimaryKey(array('id'));
         $nodes->addUniqueIndex(array('path', 'workspace_name'));
-        $nodes->addUniqueIndex(array('identifier'));
+        $nodes->addUniqueIndex(array('identifier', 'workspace_name'));
         $nodes->addIndex(array('parent'));
         $nodes->addIndex(array('type'));
         $nodes->addIndex(array('local_name', 'namespace'));


### PR DESCRIPTION
The getNodeByIdentifier method in Jackalope\Transport\DoctrineDBAL\Client fetches a node using the identifier and the workspace_name (which it should). However, the unique constraint only contains the identifier, which results in false positives when checking if a node doesn't exist yet. This updated constraint fixes that issue.
