### PR TITLE
Do not prefix dcr:name with selector prefix

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2109,8 +2109,8 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                     $result[] = array('dcr:name' => 'jcr:path', 'dcr:value' => $row[$columnPrefix . 'path'], 'dcr:selectorName' => $selectorName);
                 }
 
-                $result[] = array('dcr:name' => $selectorPrefix . 'jcr:path'       ,'dcr:value' => $row[$columnPrefix . 'path'], 'dcr:selectorName' => $selectorName);
-                $result[] = array('dcr:name' => $selectorPrefix . 'jcr:score',      'dcr:value' => 0                           , 'dcr:selectorName' => $selectorName);
+                $result[] = array('dcr:name' => 'jcr:path'       ,'dcr:value' => $row[$columnPrefix . 'path'], 'dcr:selectorName' => $selectorName);
+                $result[] = array('dcr:name' => 'jcr:score',      'dcr:value' => 0                           , 'dcr:selectorName' => $selectorName);
                 if (0 === count($qom->getColumns())) {
                     $result[] = array('dcr:name' => $selectorPrefix . 'jcr:primaryType','dcr:value' => $primaryType                , 'dcr:selectorName' => $selectorName);
                 }


### PR DESCRIPTION
The jackalope `QueryResult::getNodes` method iterates over all of the rows and extracts the paths by accessing the `dcr:name` property with the value `jcr:path`.

In doctrine-dbal however we get `c.jcr:path` (for e.g. `SELECT foo AS c`.

Is this an obvious mistake or is there some reason that this was done like this?
