### PR TITLE
Fix optimzation on getNodesData

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/dbal": ">=2.2.0,<2.6",
+        "doctrine/dbal": "~2.4",
         "phpcr/phpcr": "~2.1.0",
         "phpcr/phpcr-utils": ">=1.1.0,<1.3.x-dev",
         "jackalope/jackalope": "~1.1.1"


### PR DESCRIPTION
It appears there was a regression in SQL lite.

Isn't there a test for this?

I was getting:

```
1) Sulu\Bundle\SuluSearchBundle\Tests\Functional\SaveStructureTest::testSaveStructure
Array to string conversion

/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:643
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:584
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/jackalope/jackalope-doctrine-dbal/src/Jackalope/Transport/DoctrineDBAL/Client.php:1135
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/jackalope/jackalope-doctrine-dbal/src/Jackalope/Transport/DoctrineDBAL/Client.php:1068
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/jackalope/jackalope/src/Jackalope/ObjectManager.php:205
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/jackalope/jackalope/src/Jackalope/Session.php:277
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/jackalope/jackalope/src/Jackalope/Session.php:208
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/sulu/sulu/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php:79
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/sulu/sulu/src/Sulu/Component/Content/Mapper/ContentMapper.php:1444
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/vendor/sulu/sulu/src/Sulu/Component/Content/Mapper/ContentMapper.php:222
/home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/search-bundle/Tests/Functional/SaveStructureTest.php:17
```
