### PR TITLE
[BUG] Do not overwrite jcr:path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 
 before_script:
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+  - composer self-update
   - composer update --prefer-source --no-interaction
   - if [[ "$DB" == "mysql" ]]; then mysql -e "create database phpcr_tests;"; fi
   - if [[ "$DB" == "pgsql" ]]; then psql -c "create database phpcr_tests;" -U postgres; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 Changelog
 =========
+
 1.2
 ---
 
+* Throw Exception when user tries to select either jcr:path or jcr:score
 * The jackalope:init:dbal command now only really executes when the --force
   parameter is given.
 * Fixed Property::getNode() can return the same node multiple times if that

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2313,10 +2313,20 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                 }
             }
 
+            $reservedNames = array('jcr:path', 'jcr:score');
+
             foreach ($qom->getColumns() as $column) {
                 $selectorName = $column->getSelectorName();
                 $columnName = $column->getPropertyName();
                 $columnPrefix = isset($selectorAliases[$selectorName]) ? $selectorAliases[$selectorName] . '_' : $selectorAliases[''] . '_';
+
+
+                if (in_array($column->getColumnName(), $reservedNames)) {
+                    throw new InvalidQueryException(sprintf(
+                        'Cannot reserved name "%s". Reserved names are "%s"',
+                        $column->getColumnName(), implode('", "', $reservedNames)
+                    ));
+                }
 
                 $dcrValue = 'jcr:uuid' === $columnName
                     ? $row[$columnPrefix . 'identifier']


### PR DESCRIPTION
We had an issue where a developer selected `jcr:path` in a SELECT query. This worked in jackrabbit, but not in doctrine-dbal.

Turns out it was because `jcr:path` was being overwritten and then consequently we got the error `Path must not be of zero length` when trying to retrieve the node from the selector.

**This is more of a bug report** than a pull request I don't know how this should behave. We resolved the issue by not selecting `jcr:path`.

````
[1] PHPCR\RepositoryException: Path must not be of zero length
    at n/a
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/phpcr/phpcr-utils/src/PHPCR/Util/PathHelper.php line 269

    at PHPCR\Util\PathHelper::error('Path must not be of zero length', true)
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/phpcr/phpcr-utils/src/PHPCR/Util/PathHelper.php line 122

    at PHPCR\Util\PathHelper::normalizePath('')
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/jackalope/jackalope/src/Jackalope/ObjectManager.php line 194

    at Jackalope\ObjectManager->getNodeByPath('')
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/jackalope/jackalope/src/Jackalope/Query/Row.php line 186

    at Jackalope\Query\Row->getNode('page')
        in /home/daniel/www/sulu-cmf/sulu/src/Sulu/Component/Content/Mapper/ContentMapper.php line 1695

    at Sulu\Component\Content\Mapper\ContentMapper->rowToArray(object(Row), 'de', 'sulu_io', '/cmf/sulu_io/routes/de', array('de' => array(array('name' => 'article', 'property' => object(Property), 'templateKey' => 'complex'), array('name' => 'article', 'property' => object(Property), 'templateKey' => 'default'), array('name' => 'article', 'property' => object(Property), 'templateKey' => 'example'), array('name' => 'article', 'property' => object(Property), 'templateKey' => 'overview'))))
        in /home/daniel/www/sulu-cmf/sulu/src/Sulu/Component/Content/Mapper/ContentMapper.php line 1674

    at Sulu\Component\Content\Mapper\ContentMapper->convertQueryResultToArray(object(QueryResult), 'sulu_io', array('de'), array('de' => array(array('name' => 'article', 'property' => object(Property), 'templateKey' => 'complex'), array('name' => 'article', 'property' => object(Property), 'templateKey' => 'default'), array('name' => 'article', 'property' => object(Property), 'templateKey' => 'example'), array('name' => 'article', 'property' => object(Property), 'templateKey' => 'overview'))), '-1')
        in /home/daniel/www/sulu-cmf/sulu/src/Sulu/Component/Content/Query/ContentQueryExecutor.php line 83

    at Sulu\Component\Content\Query\ContentQueryExecutor->execute('sulu_io', array('de'), object(SmartContentQueryBuilder))
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/content-bundle/Sulu/Bundle/ContentBundle/Content/SmartContentContainer.php line 184

    at Sulu\Bundle\ContentBundle\Content\SmartContentContainer->loadData(array('dataSource' => '9638a04d-038f-47cd-8f08-a43a19a452cf', 'includeSubFolders' => false, 'category' => array(), 'tags' => array(), 'sortBy' => array(), 'sortMethod' => 'asc', 'presentAs' => array(), 'limitResult' => ''))
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/content-bundle/Sulu/Bundle/ContentBundle/Content/SmartContentContainer.php line 163

    at Sulu\Bundle\ContentBundle\Content\SmartContentContainer->getData()
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/content-bundle/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContent.php line 225

    at Sulu\Bundle\ContentBundle\Content\Types\SmartContent\SmartContent->getContentData(object(Property))
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/website-bundle/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php line 45

    at Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver->resolve(object(ExampleStructureCache))
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/website-bundle/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php line 88

    at Sulu\Bundle\WebsiteBundle\Controller\WebsiteController->getAttributes(array(), object(ExampleStructureCache), false)
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/website-bundle/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php line 40

    at Sulu\Bundle\WebsiteBundle\Controller\WebsiteController->renderStructure(object(ExampleStructureCache), array(), false, false)
        in /home/daniel/www/sulu-cmf/sulu-standard/vendor/sulu/website-bundle/Sulu/Bundle/WebsiteBundle/Controller/DefaultController.php line 39

    at Sulu\Bundle\WebsiteBundle\Controller\DefaultController->indexAction(object(ExampleStructureCache), false, false)
        in  line 

    at call_user_func_array(array(object(DefaultController), 'indexAction'), array(object(ExampleStructureCache), false, false))
        in /home/daniel/www/sulu-cmf/sulu-standard/app/bootstrap.php.cache line 2969

    at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), '1')
        in /home/daniel/www/sulu-cmf/sulu-standard/app/bootstrap.php.cache line 2931

    at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), '1', true)
        in /home/daniel/www/sulu-cmf/sulu-standard/app/bootstrap.php.cache line 3080

    at Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle(object(Request), '1', true)
        in /home/daniel/www/sulu-cmf/sulu-standard/app/bootstrap.php.cache line 2330

    at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
        in /home/daniel/www/sulu-cmf/sulu-standard/web/website.php line 37
````