### PR TITLE
Numerical sorting

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -92,6 +92,7 @@ class RepositorySchema extends Schema
         $nodes->addColumn('identifier', 'string');
         $nodes->addColumn('type', 'string');
         $nodes->addColumn('props', 'text');
+        $nodes->addColumn('numerical_props', 'text', array('notnull' => false));
         $nodes->addColumn('depth', 'integer');
         $nodes->addColumn('sort_order', 'integer', array('notnull' => false));
         $nodes->setPrimaryKey(array('id'));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,9 +40,11 @@ $dbConn = \Doctrine\DBAL\DriverManager::getConnection(array(
 ));
 
 // recreate database schema
-$options = array('disable_fks' => $dbConn->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform);
-$repositorySchema = new \Jackalope\Transport\DoctrineDBAL\RepositorySchema($options, $dbConn);
-$repositorySchema->reset();
+if (!getenv('JACKALOPE_NO_TEST_DB_INIT')) {
+    $options = array('disable_fks' => $dbConn->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform);
+    $repositorySchema = new \Jackalope\Transport\DoctrineDBAL\RepositorySchema($options, $dbConn);
+    $repositorySchema->reset();
+}
 
 // some constants
 define('SPEC_VERSION_DESC',             'jcr.specification.version');


### PR DESCRIPTION
This PR adds an extra column `numerical_props` which is populated with `LONG`, `DECIMAL` and `FLOAT` values (in an XML doc).

When sorting the query will ORDER first by casting the value of the property in the `numberical_props` column and then by the standard `props` column.

````
SELECT ... WHERE ...  ORDER BY 
CAST(EXTRACTVALUE(n0.numerical_props, '//sv:property[@sv:name="sulu:order"]/sv:value[1]') AS DECIMAL),
EXTRACTVALUE(n0.props, '//sv:property[@sv:name="sulu:order"]/sv:value[1]')
````

## Benchmarking

- The performance should be the same when no ORDER BY is issued.
- We should expect a small performance penalty when ORDER BY is issued.

Master:

````
SELECT \* FROM [nt:unstructured];
2143 rows in set (1.91051 sec)
2143 rows in set (1.96289 sec)
2143 rows in set (1.87208 sec)
SELECT \* FROM [nt:unstructured] ORDER BY [i18n:de-title];
2143 rows in set (1.99825 sec)
2143 rows in set (1.99817 sec)
2143 rows in set (2.02555 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE i18n:de-title IS NOT NULL ORDER BY [i18n:de-title];
330 rows in set (1.63120 sec)
330 rows in set (1.63655 sec)
330 rows in set (1.65118 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') AND i18n:de-title IS NOT NULL ORDER BY [sulu:order], [i18n:de-title] DESC;
57 rows in set (0.58143 sec)
57 rows in set (0.58995 sec)
57 rows in set (0.59365 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service');
57 rows in set (0.51940 sec)
57 rows in set (0.51984 sec)
57 rows in set (0.49899 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') ORDER BY [i18n:de-title];
57 rows in set (0.53426 sec)
57 rows in set (0.51620 sec)
57 rows in set (0.53260 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') AND i18n:de-title IS NOT NULL ORDER BY [i18n:de-title];
57 rows in set (0.54159 sec)
57 rows in set (0.55744 sec)
57 rows in set (0.55175 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') AND i18n:de-title IS NOT NULL ORDER BY [sulu:order], [i18n:de-title] DESC;
57 rows in set (0.55607 sec)
57 rows in set (0.59970 sec)
57 rows in set (0.58270 sec)
````

This PR:

````
SELECT \* FROM [nt:unstructured];
2143 rows in set (1.84274 sec)
2143 rows in set (1.94709 sec)
2143 rows in set (1.86058 sec)
SELECT \* FROM [nt:unstructured] ORDER BY [i18n:de-title];
2143 rows in set (2.04875 sec)
2143 rows in set (2.04055 sec)
2143 rows in set (2.00308 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE i18n:de-title IS NOT NULL ORDER BY [i18n:de-title];
330 rows in set (1.63383 sec)
330 rows in set (1.63438 sec)
330 rows in set (1.63745 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') AND i18n:de-title IS NOT NULL ORDER BY [sulu:order], [i18n:de-title] DESC;
57 rows in set (0.57677 sec)
57 rows in set (0.60930 sec)
57 rows in set (0.58204 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service');
57 rows in set (0.48024 sec)
57 rows in set (0.47330 sec)
57 rows in set (0.48214 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') ORDER BY [i18n:de-title];
57 rows in set (0.52143 sec)
57 rows in set (0.52957 sec)
57 rows in set (0.52393 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') AND i18n:de-title IS NOT NULL ORDER BY [i18n:de-title];
57 rows in set (0.54349 sec)
57 rows in set (0.55270 sec)
57 rows in set (0.54978 sec)
SELECT \* FROM [nt:unstructured] AS a WHERE ISDESCENDANTNODE(a, '/cmf/stanton/contents/service') AND i18n:de-title IS NOT NULL ORDER BY [sulu:order], [i18n:de-title] DESC;
57 rows in set (0.56815 sec)
57 rows in set (0.58603 sec)
57 rows in set (0.55674 sec)
````