### PR TITLE
fix issue with postgres 9

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -840,7 +840,7 @@ class QOMWalker
             return sprintf("EXTRACTVALUE(%s.props, '//sv:property[@sv:name=\"%s\"]/sv:value[%d]/@%s')", $alias, $property, $valueIndex, $attribute);
         }
         if ($this->platform instanceof PostgreSqlPlatform) {
-            return sprintf("(xpath('//sv:property[@sv:name=\"%s\"]/sv:value[%d]/@%s', CAST(%s.props AS xml), %s))[1]::text", $property, $valueIndex, $attribute, $alias, $this->sqlXpathPostgreSQLNamespaces());
+            return sprintf("CAST((xpath('//sv:property[@sv:name=\"%s\"]/sv:value[%d]/@%s', CAST(%s.props AS xml), %s))[1]::text AS bigint)", $property, $valueIndex, $attribute, $alias, $this->sqlXpathPostgreSQLNamespaces());
         }
         if ($this->platform instanceof SqlitePlatform) {
             return sprintf("EXTRACTVALUE(%s.props, '//sv:property[@sv:name=\"%s\"]/sv:value[%d]/@%s')", $alias, $property, $valueIndex, $attribute);


### PR DESCRIPTION
fix #230

was able to reproduce locally with psql 9.3.5. travis does not tell its postgres version in the build system info, only all other information you could think of, so not sure if its psql 9 only.

@lsmith77 can you check this branch on your system to see if the changes work on your postgres version?

i don't understand exactly what is happening or if its intended, but looks like an issue with auto-detecting the type when the value is 0. if this really fixes the issue, we need it anyways as postgres versions with this issue are out there.

@dantleech while debugging, i tried to query the length value in the select. but this query was considered invalid:
```
            SELECT LENGTH(data.[empty-value]) AS length
            FROM [nt:unstructured] AS data
            WHERE
              data.[empty-value] IS NOT NULL
```
is this a known issue, or not supposed to work anyways or should we create an issue for the query parser?