### PR TITLE
validate namespaces in paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.2
 ---
 
+* Validate namespaces in node paths and throws NamespaceException on unknown prefixes.
 * Throw Exception when user tries to select either jcr:path or jcr:score
 * The jackalope:init:dbal command now only really executes when the --force
   parameter is given.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "doctrine/dbal": "~2.4",
         "phpcr/phpcr": "~2.1.2",
-        "phpcr/phpcr-utils": "~1.2",
+        "phpcr/phpcr-utils": "~1.2,>=1.2.4",
         "jackalope/jackalope": "~1.2.0"
     },
     "provide": {


### PR DESCRIPTION
fix #208

until a version of phpcr-utils having https://github.com/phpcr/phpcr-utils/pull/145 is used, the extra argument is ignored and no validation really happens.