### PR TITLE
Always initialize the connection if it is closed

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2600,7 +2600,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     private function initConnection()
     {
-        if (true === $this->connectionInitialized) {
+        if (true === $this->conn->isConnected() && true === $this->connectionInitialized) {
             return;
         }
 


### PR DESCRIPTION
Always initialize if the connection is closed. Fixes #249 

The DoctrineBundle [now closes connections](https://github.com/doctrine/DoctrineBundle/commit/2f8d7263c4c44445b51fc2d9bf71d21f7016347d) on kernel#shutdown, which can cause issues for functional tests.

When the connection is reestablished the registered functions (e.g. CONCAT for sqlite) are lost. This PR will reinitialize if it sees that the connection is closed.

