### PR TITLE
dbal fix is backported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/dbal": "~2.5,>=2.5.0",
+        "doctrine/dbal": ">=2.4.5,<3.0.x-dev",
         "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "~1.2,>=1.2.4",
         "jackalope/jackalope": "~1.2.0"


### PR DESCRIPTION
follow up of #247 

this should fail for now, so that we can compare. then we can try the branch https://github.com/doctrine/dbal/compare/2.4...dbu:backport-creation-fix-to-2.4?expand=1 and it should no longer fail, then do a PR with that branch...