### PR TITLE
Respect direction when sorting by numerical properties

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -763,8 +763,9 @@ class QOMWalker
 
                 $numericalSelector = $this->sqlXpathExtractValue($alias, $property, 'numerical_props');
 
-                $sql = sprintf('CAST(%s AS DECIMAL), %s',
+                $sql = sprintf('CAST(%s AS DECIMAL) %s, %s',
                     $numericalSelector,
+                    $direction,
                     $sql
                 );
             }

--- a/tests/Jackalope/Transport/DoctrineDBAL/Query/QOMWalkerTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/Query/QOMWalkerTest.php
@@ -224,12 +224,12 @@ class QOMWalkerTest extends TestCase
         switch ($driver) {
             case 'pdo_pgsql':
                 $ordering = 
-                    "CAST((xpath('//sv:property[@sv:name=\"foobar\"]/sv:value[1]/text()', CAST(n0.numerical_props AS xml), ARRAY[ARRAY['sv', 'http://www.jcp.org/jcr/sv/1.0']]))[1]::text AS DECIMAL), " . 
+                    "CAST((xpath('//sv:property[@sv:name=\"foobar\"]/sv:value[1]/text()', CAST(n0.numerical_props AS xml), ARRAY[ARRAY['sv', 'http://www.jcp.org/jcr/sv/1.0']]))[1]::text AS DECIMAL) ASC, " . 
                    "(xpath('//sv:property[@sv:name=\"foobar\"]/sv:value[1]/text()', CAST(n0.props AS xml), ARRAY[ARRAY['sv', 'http://www.jcp.org/jcr/sv/1.0']]))[1]::text ASC";
                 break;
             default:
                 $ordering = 
-                    "CAST(EXTRACTVALUE(n0.numerical_props, '//sv:property[@sv:name=\"foobar\"]/sv:value[1]') AS DECIMAL), " .
+                    "CAST(EXTRACTVALUE(n0.numerical_props, '//sv:property[@sv:name=\"foobar\"]/sv:value[1]') AS DECIMAL) ASC, " .
                     "EXTRACTVALUE(n0.props, '//sv:property[@sv:name=\"foobar\"]/sv:value[1]') ASC";
         }
 


### PR DESCRIPTION
Currently the sort direction is not taken into account when ordering by numerical properties.