### PR TITLE
add version restore functionality to transport layer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,5 @@
         "branch-alias": {
             "dev-master": "1.3-dev"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/danrot/jackalope.git"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,15 +42,5 @@
         "branch-alias": {
             "dev-master": "1.3-dev"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/danrot/jackalope.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/danrot/phpcr-utils.git"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,11 @@
         "branch-alias": {
             "dev-master": "1.3-dev"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/danrot/jackalope.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/danrot/jackalope.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/danrot/phpcr-utils.git"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/dbal": ">=2.4.5,<3.0.x-dev",
         "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "^1.2.8",
-        "jackalope/jackalope": "dev-versioning as 1.3.0"
+        "jackalope/jackalope": "dev-version-restore as 1.3.0"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"
@@ -42,5 +42,15 @@
         "branch-alias": {
             "dev-master": "1.3-dev"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/danrot/jackalope.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/danrot/phpcr-api-tests.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "doctrine/dbal": ">=2.4.5,<3.0.x-dev",
         "phpcr/phpcr": "~2.1.2",
-        "phpcr/phpcr-utils": "dev-versioning as 1.2.9",
+        "phpcr/phpcr-utils": "^1.2.8",
         "jackalope/jackalope": "dev-versioning as 1.3.0"
     },
     "provide": {

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Transport\DoctrineDBAL;
 
+use Jackalope\Transport\LabelExistsVersionException;
 use Jackalope\Version\GenericVersioningInterface;
 use Jackalope\Version\VersionHandler;
 use PHPCR\LoginException;
@@ -2633,6 +2634,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     }
 
     /**
+<<<<<<< 34946d715902b6bf1374bedb1dafe3d18d472739
      * {@inheritDoc}
      */
     public function checkinItem($path)
@@ -2676,4 +2678,34 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
         $this->versionHandler = $versionHandler;
     }
+
+    /**
+     * Adds the label <code>label</code> to the specified version.
+     *
+     * @param string $versionName the absolute path to the version
+     * @param string $label
+     * @param boolean $moveLabel
+     *
+     * @throws LabelExistsVersionException if, the label is set to another version and
+     * the parameter moveLabel is set to false.
+     *
+     * @throws RepositoryException in case of an other error.
+     */
+    public function addVersionLabel($versionName, $label, $moveLabel)
+    {
+        // TODO: Implement addVersionLabel() method.
+    }
+
+    /**
+     * Removes a label from the specified version.
+     *
+     * @param string $versionPath the absolute path to the version.
+     * @param string $label the label, that has to be removed.
+     */
+    public function removeVersionLabel($versionPath, $label)
+    {
+        // TODO: Implement removeVersionLabel() method.
+    }
 }
+
+

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -30,6 +30,8 @@ use PHPCR\Util\QOM\Sql2ToQomQueryConverter;
 use PHPCR\Util\ValueConverter;
 use PHPCR\Util\UUIDHelper;
 use PHPCR\Util\PathHelper;
+use PHPCR\Version\LabelExistsVersionException;
+use PHPCR\Version\VersionException;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
@@ -51,8 +53,6 @@ use Jackalope\NodeType\NodeTypeDefinition;
 use Jackalope\FactoryInterface;
 use Jackalope\NotImplementedException;
 use Jackalope\NodeType\NodeProcessor;
-use PHPCR\Version\LabelExistsVersionException;
-use PHPCR\Version\VersionException;
 
 /**
  * Class to handle the communication between Jackalope and RDBMS via Doctrine DBAL.
@@ -2664,7 +2664,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     public function restoreItem($removeExisting, $versionPath, $path)
     {
-        throw new NotImplementedException();
+        return $this->versionHandler->restoreItem($removeExisting, $versionPath, $path);
     }
 
     /**

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Transport\DoctrineDBAL;
 
+use Jackalope\NamespaceRegistry;
 use Jackalope\Version\GenericVersioningInterface;
 use Jackalope\Version\VersionHandler;
 use PHPCR\LoginException;
@@ -149,6 +150,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     private $coreNamespaces = array(
         NamespaceRegistryInterface::PREFIX_EMPTY => NamespaceRegistryInterface::NAMESPACE_EMPTY,
+        NamespaceRegistry::PREFIX_REP => NamespaceRegistry::NAMESPACE_REP,
         NamespaceRegistryInterface::PREFIX_JCR => NamespaceRegistryInterface::NAMESPACE_JCR,
         NamespaceRegistryInterface::PREFIX_NT => NamespaceRegistryInterface::NAMESPACE_NT,
         NamespaceRegistryInterface::PREFIX_MIX => NamespaceRegistryInterface::NAMESPACE_MIX,

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2,7 +2,6 @@
 
 namespace Jackalope\Transport\DoctrineDBAL;
 
-use Jackalope\Transport\LabelExistsVersionException;
 use Jackalope\Version\GenericVersioningInterface;
 use Jackalope\Version\VersionHandler;
 use PHPCR\LoginException;
@@ -52,6 +51,7 @@ use Jackalope\NodeType\NodeTypeDefinition;
 use Jackalope\FactoryInterface;
 use Jackalope\NotImplementedException;
 use Jackalope\NodeType\NodeProcessor;
+use PHPCR\Version\LabelExistsVersionException;
 use PHPCR\Version\VersionException;
 
 /**
@@ -1917,6 +1917,16 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     }
 
     /**
+     * Returns a handler for the versioning mechanism
+     *
+     * @return VersionHandler
+     */
+    private function getVersionHandler()
+    {
+        return $this->versionHandler;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function storeNodes(array $operations)
@@ -2634,7 +2644,6 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     }
 
     /**
-<<<<<<< 34946d715902b6bf1374bedb1dafe3d18d472739
      * {@inheritDoc}
      */
     public function checkinItem($path)

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2716,5 +2716,3 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         // TODO: Implement removeVersionLabel() method.
     }
 }
-
-

--- a/tests/ImplementationLoader.php
+++ b/tests/ImplementationLoader.php
@@ -53,10 +53,7 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     'Query\\XPath', // Query language 'xpath' not implemented.
                     'Query\\Sql1', // Query language 'sql' is legacy and only makes sense with jackrabbit
                     'Writing\\CloneMethodsTest', // TODO: Support for workspace->clone, node->update, node->getCorrespondingNodePath
-
-                    // TODO fully implement versioning
-                    'Versioning\\VersionManagerTest',
-                    'Versioning\\VersionTest',
+                    'Versioning\\SimpleVersionTest'
         );
 
         $this->unsupportedTests = array(
@@ -91,6 +88,8 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     'Versioning\\VersionHistoryTest::testDeleteVersion',
                     'Versioning\\VersionHistoryTest::testDeleteLatestVersion',
                     'Versioning\\VersionHistoryTest::testDeleteUnexistingVersion',
+                    'Versioning\\VersionManagerTest::testRestoreRootVersion',
+                    'Versioning\\VersionManagerTest::testWriteNotCheckedOutVersion',
         );
 
         if ($connection->getDatabasePlatform() instanceof Doctrine\DBAL\Platforms\SqlitePlatform) {

--- a/tests/ImplementationLoader.php
+++ b/tests/ImplementationLoader.php
@@ -53,6 +53,11 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     'Query\\XPath', // Query language 'xpath' not implemented.
                     'Query\\Sql1', // Query language 'sql' is legacy and only makes sense with jackrabbit
                     'Writing\\CloneMethodsTest', // TODO: Support for workspace->clone, node->update, node->getCorrespondingNodePath
+
+                    // TODO fully implement versioning
+                    'Versioning\\VersionHistoryTest',
+                    'Versioning\\VersionManagerTest',
+                    'Versioning\\VersionTest',
         );
 
         $this->unsupportedTests = array(
@@ -82,15 +87,6 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     // TODO: implement creating workspace with source
                     'WorkspaceManagement\\WorkspaceManagementTest::testCreateWorkspaceWithSource',
                     'WorkspaceManagement\\WorkspaceManagementTest::testCreateWorkspaceWithInvalidSource',
-
-                    // TODO: implement remove version
-                    'Versioning\\VersionHistoryTest::testDeleteVersion',
-                    'Versioning\\VersionHistoryTest::testDeleteLatestVersion',
-                    'Versioning\\VersionHistoryTest::testDeleteUnexistingVersion',
-                    'Versioning\\VersionManagerTest::testRestoreByPathAndName',
-                    'Versioning\\VersionManagerTest::testRestoreByVersionObject',
-                    'Versioning\\VersionManagerTest::testRestoreRootVersion',
-                    'Versioning\\VersionManagerTest::testWriteNotCheckedOutVersion',
         );
 
         if ($connection->getDatabasePlatform() instanceof Doctrine\DBAL\Platforms\SqlitePlatform) {

--- a/tests/ImplementationLoader.php
+++ b/tests/ImplementationLoader.php
@@ -55,7 +55,6 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     'Writing\\CloneMethodsTest', // TODO: Support for workspace->clone, node->update, node->getCorrespondingNodePath
 
                     // TODO fully implement versioning
-                    'Versioning\\VersionHistoryTest',
                     'Versioning\\VersionManagerTest',
                     'Versioning\\VersionTest',
         );

--- a/tests/ImplementationLoader.php
+++ b/tests/ImplementationLoader.php
@@ -86,6 +86,11 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     // TODO: implement creating workspace with source
                     'WorkspaceManagement\\WorkspaceManagementTest::testCreateWorkspaceWithSource',
                     'WorkspaceManagement\\WorkspaceManagementTest::testCreateWorkspaceWithInvalidSource',
+
+                    // TODO: implement remove version
+                    'Versioning\\VersionHistoryTest::testDeleteVersion',
+                    'Versioning\\VersionHistoryTest::testDeleteLatestVersion',
+                    'Versioning\\VersionHistoryTest::testDeleteUnexistingVersion',
         );
 
         if ($connection->getDatabasePlatform() instanceof Doctrine\DBAL\Platforms\SqlitePlatform) {

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -137,19 +137,19 @@ class DBUnitFixtureXML extends XMLDocument
             'type'           => 'nt:unstructured',
             'props'          => '<?xml version="1.0" encoding="UTF-8"?>'
                              . '<sv:node xmlns:crx="http://www.day.com/crx/1.0"'
-                             . 'xmlns:lx="http://flux-cms.org/2.0"'
-                             . 'xmlns:test="http://liip.to/jackalope"'
-                             . 'xmlns:mix="http://www.jcp.org/jcr/mix/1.0"'
-                             . 'xmlns:sling="http://sling.apache.org/jcr/sling/1.0"'
-                             . 'xmlns:nt="http://www.jcp.org/jcr/nt/1.0"'
-                             . 'xmlns:fn_old="http://www.w3.org/2004/10/xpath-functions"'
-                             . 'xmlns:fn="http://www.w3.org/2005/xpath-functions"'
-                             . 'xmlns:vlt="http://www.day.com/jcr/vault/1.0"'
-                             . 'xmlns:xs="http://www.w3.org/2001/XMLSchema"'
-                             . 'xmlns:new_prefix="http://a_new_namespace"'
-                             . 'xmlns:jcr="http://www.jcp.org/jcr/1.0"'
-                             . 'xmlns:sv="http://www.jcp.org/jcr/sv/1.0"'
-                             . 'xmlns:rep="internal" />',
+                             . ' xmlns:lx="http://flux-cms.org/2.0"'
+                             . ' xmlns:test="http://liip.to/jackalope"'
+                             . ' xmlns:mix="http://www.jcp.org/jcr/mix/1.0"'
+                             . ' xmlns:sling="http://sling.apache.org/jcr/sling/1.0"'
+                             . ' xmlns:nt="http://www.jcp.org/jcr/nt/1.0"'
+                             . ' xmlns:fn_old="http://www.w3.org/2004/10/xpath-functions"'
+                             . ' xmlns:fn="http://www.w3.org/2005/xpath-functions"'
+                             . ' xmlns:vlt="http://www.day.com/jcr/vault/1.0"'
+                             . ' xmlns:xs="http://www.w3.org/2001/XMLSchema"'
+                             . ' xmlns:new_prefix="http://a_new_namespace"'
+                             . ' xmlns:jcr="http://www.jcp.org/jcr/1.0"'
+                             . ' xmlns:sv="http://www.jcp.org/jcr/sv/1.0"'
+                             . ' xmlns:rep="internal" />',
             'depth'          => 0,
             'sort_order'     => 0,
         ));

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -47,8 +47,8 @@ class DBUnitFixtureXML extends XMLDocument
     private $rootNodes;
 
     /**
-     * @param string $file    - file path
-     * @param int    $options - libxml option constants: http://www.php.net/manual/en/libxml.constants.php
+     * @param string $file - file path
+     * @param int $options - libxml option constants: http://www.php.net/manual/en/libxml.constants.php
      */
     public function __construct($file, $options = null)
     {
@@ -65,13 +65,16 @@ class DBUnitFixtureXML extends XMLDocument
         $this->appendChild($this->createElement('dataset'));
 
         // purge binary in case no binary properties are in fixture
-        $this->ensureTableExists('phpcr_binarydata', array(
-            'node_id',
-            'property_name',
-            'workspace_name',
-            'idx',
-            'data',
-        ));
+        $this->ensureTableExists(
+            'phpcr_binarydata',
+            array(
+                'node_id',
+                'property_name',
+                'workspace_name',
+                'idx',
+                'data',
+            )
+        );
 
         return $this;
     }
@@ -99,7 +102,7 @@ class DBUnitFixtureXML extends XMLDocument
      *
      * If the root node is not called jcr:root, autogenerate a root node.
      *
-     * @param string       $workspaceName
+     * @param string $workspaceName
      * @param \DOMNodeList $nodes
      *
      * @return DBUnitFixtureXML
@@ -159,7 +162,7 @@ class DBUnitFixtureXML extends XMLDocument
     {
         $properties = $this->getAttributes($node);
         $uuid = isset($properties['jcr:uuid']['value'][0])
-            ? (string) $properties['jcr:uuid']['value'][0] : UUIDHelper::generateUUID();
+            ? (string)$properties['jcr:uuid']['value'][0] : UUIDHelper::generateUUID();
         $this->ids[$uuid] = $id = isset($this->expectedNodes[$uuid])
             ? $this->expectedNodes[$uuid] : self::$idCounter++;
 
@@ -179,7 +182,9 @@ class DBUnitFixtureXML extends XMLDocument
                 throw new \InvalidArgumentException('"' . $propertyData['type'] . '" is not a valid JCR type.');
             }
 
-            $phpcrNode->appendChild($this->createPropertyNode($workspaceName, $propertyName, $propertyData, $id, $dom, $phpcrNode));
+            $phpcrNode->appendChild(
+                $this->createPropertyNode($workspaceName, $propertyName, $propertyData, $id, $dom, $phpcrNode)
+            );
         }
 
         list($parentPath, $childPath) = $this->getPath($node);
@@ -191,11 +196,11 @@ class DBUnitFixtureXML extends XMLDocument
         }
 
         if ($namespace == 'jcr' && $name == 'root') {
-            $id         = 1;
-            $childPath  = '/';
+            $id = 1;
+            $childPath = '/';
             $parentPath = '';
-            $name       = '';
-            $namespace  = '';
+            $name = '';
+            $namespace = '';
         }
 
         if (isset($properties['jcr:mixinTypes'])
@@ -224,7 +229,7 @@ class DBUnitFixtureXML extends XMLDocument
     public function addReferences()
     {
         foreach ($this->references as $type => $references) {
-            $table = 'phpcr_nodes_'.$type.'s';
+            $table = 'phpcr_nodes_' . $type . 's';
 
             // make sure we have the references even if there is not a single entry in it to have it truncated
             $this->ensureTableExists($table, array('source_id', 'source_property_name', 'target_id'));
@@ -272,7 +277,10 @@ class DBUnitFixtureXML extends XMLDocument
         $isMultiValue = false;
         if ($name == 'jcr:mixinTypes'
             || count($values) > 1
-            || ($node->hasAttributeNS($this->namespaces['sv'], 'multiple') && $node->getAttributeNS($this->namespaces['sv'], 'multiple') == 'true')
+            || ($node->hasAttributeNS($this->namespaces['sv'], 'multiple') && $node->getAttributeNS(
+                    $this->namespaces['sv'],
+                    'multiple'
+                ) == 'true')
         ) {
             $isMultiValue = true;
         }
@@ -289,14 +297,31 @@ class DBUnitFixtureXML extends XMLDocument
 
         $binaryDataIdx = 0;
         foreach ($propertyData['value'] as $value) {
-            $propertyNode->appendChild($this->createValueNodeByType($workspaceName, $propertyData['type'], $value, $id, $propertyName, $binaryDataIdx++, $dom));
+            $propertyNode->appendChild(
+                $this->createValueNodeByType(
+                    $workspaceName,
+                    $propertyData['type'],
+                    $value,
+                    $id,
+                    $propertyName,
+                    $binaryDataIdx++,
+                    $dom
+                )
+            );
         }
 
         return $propertyNode;
     }
 
-    public function createValueNodeByType($workspaceName, $type, $value, $id, $propertyName, $binaryDataIdx, \DOMDocument $dom)
-    {
+    public function createValueNodeByType(
+        $workspaceName,
+        $type,
+        $value,
+        $id,
+        $propertyName,
+        $binaryDataIdx,
+        \DOMDocument $dom
+    ) {
         $length = is_scalar($value) ? strlen($value) : null;
         switch ($type) {
             case 'binary':
@@ -374,10 +399,10 @@ class DBUnitFixtureXML extends XMLDocument
     }
 
     /**
-     * @param int    $id
+     * @param int $id
      * @param string $propertyName
      * @param string $workspaceName
-     * @param int    $idx
+     * @param int $idx
      * @param string $data
      *
      * @return int - length of base64 decoded string

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -126,6 +126,62 @@ class DBUnitFixtureXML extends XMLDocument
         $uuid = UUIDHelper::generateUUID();
         $this->ids[$uuid] = self::$idCounter++;
 
+        $this->addRow('phpcr_nodes', array(
+            'id'             => self::$idCounter++,
+            'path'           => '/jcr:system',
+            'parent'         => '/',
+            'local_name'     => 'jcr:system',
+            'namespace'      => 'http://www.jcp.org/jcr/1.0',
+            'workspace_name' => $workspaceName,
+            'identifier'     => UUIDHelper::generateUUID(),
+            'type'           => 'rep:system',
+            'props'          => '<?xml version="1.0" encoding="UTF-8"?>'
+                . '<sv:node xmlns:crx="http://www.day.com/crx/1.0"'
+                . ' xmlns:lx="http://flux-cms.org/2.0"'
+                . ' xmlns:test="http://liip.to/jackalope"'
+                . ' xmlns:mix="http://www.jcp.org/jcr/mix/1.0"'
+                . ' xmlns:sling="http://sling.apache.org/jcr/sling/1.0"'
+                . ' xmlns:nt="http://www.jcp.org/jcr/nt/1.0"'
+                . ' xmlns:fn_old="http://www.w3.org/2004/10/xpath-functions"'
+                . ' xmlns:fn="http://www.w3.org/2005/xpath-functions"'
+                . ' xmlns:vlt="http://www.day.com/jcr/vault/1.0"'
+                . ' xmlns:xs="http://www.w3.org/2001/XMLSchema"'
+                . ' xmlns:new_prefix="http://a_new_namespace"'
+                . ' xmlns:jcr="http://www.jcp.org/jcr/1.0"'
+                . ' xmlns:sv="http://www.jcp.org/jcr/sv/1.0"'
+                . ' xmlns:rep="internal" />',
+            'depth'          => 1,
+            'sort_order'     => 0,
+        ));
+
+        $this->addRow('phpcr_nodes', array(
+            'id'             => self::$idCounter++,
+            'path'           => '/jcr:system/jcr:versionStorage',
+            'parent'         => '/jcr:system',
+            'local_name'     => 'jcr:versionStorage',
+            'namespace'      => 'http://www.jcp.org/jcr/1.0',
+            'workspace_name' => $workspaceName,
+            'identifier'     => UUIDHelper::generateUUID(),
+            'type'           => 'rep:versionStorage',
+            'props'          => '<?xml version="1.0" encoding="UTF-8"?>'
+                . '<sv:node xmlns:crx="http://www.day.com/crx/1.0"'
+                . ' xmlns:lx="http://flux-cms.org/2.0"'
+                . ' xmlns:test="http://liip.to/jackalope"'
+                . ' xmlns:mix="http://www.jcp.org/jcr/mix/1.0"'
+                . ' xmlns:sling="http://sling.apache.org/jcr/sling/1.0"'
+                . ' xmlns:nt="http://www.jcp.org/jcr/nt/1.0"'
+                . ' xmlns:fn_old="http://www.w3.org/2004/10/xpath-functions"'
+                . ' xmlns:fn="http://www.w3.org/2005/xpath-functions"'
+                . ' xmlns:vlt="http://www.day.com/jcr/vault/1.0"'
+                . ' xmlns:xs="http://www.w3.org/2001/XMLSchema"'
+                . ' xmlns:new_prefix="http://a_new_namespace"'
+                . ' xmlns:jcr="http://www.jcp.org/jcr/1.0"'
+                . ' xmlns:sv="http://www.jcp.org/jcr/sv/1.0"'
+                . ' xmlns:rep="internal" />',
+            'depth'          => 2,
+            'sort_order'     => 0,
+        ));
+
         return $this->addRow('phpcr_nodes', array(
             'id'             => $this->ids[$uuid],
             'path'           => '/',

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -47,8 +47,8 @@ class DBUnitFixtureXML extends XMLDocument
     private $rootNodes;
 
     /**
-     * @param string $file - file path
-     * @param int $options - libxml option constants: http://www.php.net/manual/en/libxml.constants.php
+     * @param string $file    - file path
+     * @param int    $options - libxml option constants: http://www.php.net/manual/en/libxml.constants.php
      */
     public function __construct($file, $options = null)
     {
@@ -65,16 +65,13 @@ class DBUnitFixtureXML extends XMLDocument
         $this->appendChild($this->createElement('dataset'));
 
         // purge binary in case no binary properties are in fixture
-        $this->ensureTableExists(
-            'phpcr_binarydata',
-            array(
-                'node_id',
-                'property_name',
-                'workspace_name',
-                'idx',
-                'data',
-            )
-        );
+        $this->ensureTableExists('phpcr_binarydata', array(
+            'node_id',
+            'property_name',
+            'workspace_name',
+            'idx',
+            'data',
+        ));
 
         return $this;
     }
@@ -102,7 +99,7 @@ class DBUnitFixtureXML extends XMLDocument
      *
      * If the root node is not called jcr:root, autogenerate a root node.
      *
-     * @param string $workspaceName
+     * @param string       $workspaceName
      * @param \DOMNodeList $nodes
      *
      * @return DBUnitFixtureXML
@@ -162,7 +159,7 @@ class DBUnitFixtureXML extends XMLDocument
     {
         $properties = $this->getAttributes($node);
         $uuid = isset($properties['jcr:uuid']['value'][0])
-            ? (string)$properties['jcr:uuid']['value'][0] : UUIDHelper::generateUUID();
+            ? (string) $properties['jcr:uuid']['value'][0] : UUIDHelper::generateUUID();
         $this->ids[$uuid] = $id = isset($this->expectedNodes[$uuid])
             ? $this->expectedNodes[$uuid] : self::$idCounter++;
 
@@ -182,9 +179,7 @@ class DBUnitFixtureXML extends XMLDocument
                 throw new \InvalidArgumentException('"' . $propertyData['type'] . '" is not a valid JCR type.');
             }
 
-            $phpcrNode->appendChild(
-                $this->createPropertyNode($workspaceName, $propertyName, $propertyData, $id, $dom, $phpcrNode)
-            );
+            $phpcrNode->appendChild($this->createPropertyNode($workspaceName, $propertyName, $propertyData, $id, $dom, $phpcrNode));
         }
 
         list($parentPath, $childPath) = $this->getPath($node);
@@ -196,11 +191,11 @@ class DBUnitFixtureXML extends XMLDocument
         }
 
         if ($namespace == 'jcr' && $name == 'root') {
-            $id = 1;
-            $childPath = '/';
+            $id         = 1;
+            $childPath  = '/';
             $parentPath = '';
-            $name = '';
-            $namespace = '';
+            $name       = '';
+            $namespace  = '';
         }
 
         if (isset($properties['jcr:mixinTypes'])
@@ -229,7 +224,7 @@ class DBUnitFixtureXML extends XMLDocument
     public function addReferences()
     {
         foreach ($this->references as $type => $references) {
-            $table = 'phpcr_nodes_' . $type . 's';
+            $table = 'phpcr_nodes_'.$type.'s';
 
             // make sure we have the references even if there is not a single entry in it to have it truncated
             $this->ensureTableExists($table, array('source_id', 'source_property_name', 'target_id'));
@@ -277,10 +272,7 @@ class DBUnitFixtureXML extends XMLDocument
         $isMultiValue = false;
         if ($name == 'jcr:mixinTypes'
             || count($values) > 1
-            || ($node->hasAttributeNS($this->namespaces['sv'], 'multiple') && $node->getAttributeNS(
-                    $this->namespaces['sv'],
-                    'multiple'
-                ) == 'true')
+            || ($node->hasAttributeNS($this->namespaces['sv'], 'multiple') && $node->getAttributeNS($this->namespaces['sv'], 'multiple') == 'true')
         ) {
             $isMultiValue = true;
         }
@@ -297,31 +289,14 @@ class DBUnitFixtureXML extends XMLDocument
 
         $binaryDataIdx = 0;
         foreach ($propertyData['value'] as $value) {
-            $propertyNode->appendChild(
-                $this->createValueNodeByType(
-                    $workspaceName,
-                    $propertyData['type'],
-                    $value,
-                    $id,
-                    $propertyName,
-                    $binaryDataIdx++,
-                    $dom
-                )
-            );
+            $propertyNode->appendChild($this->createValueNodeByType($workspaceName, $propertyData['type'], $value, $id, $propertyName, $binaryDataIdx++, $dom));
         }
 
         return $propertyNode;
     }
 
-    public function createValueNodeByType(
-        $workspaceName,
-        $type,
-        $value,
-        $id,
-        $propertyName,
-        $binaryDataIdx,
-        \DOMDocument $dom
-    ) {
+    public function createValueNodeByType($workspaceName, $type, $value, $id, $propertyName, $binaryDataIdx, \DOMDocument $dom)
+    {
         $length = is_scalar($value) ? strlen($value) : null;
         switch ($type) {
             case 'binary':
@@ -399,10 +374,10 @@ class DBUnitFixtureXML extends XMLDocument
     }
 
     /**
-     * @param int $id
+     * @param int    $id
      * @param string $propertyName
      * @param string $workspaceName
-     * @param int $idx
+     * @param int    $idx
      * @param string $data
      *
      * @return int - length of base64 decoded string

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -114,11 +114,6 @@ class DBUnitFixtureXML extends XMLDocument
             $this->rootNodes[$workspaceName] = true;
         }
 
-        $srcDom = new \Jackalope\Test\Fixture\JCRSystemXML(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'system.xml');
-        foreach ($srcDom->load()->getNodes() as $node) {
-            $this->addNode($workspaceName, $node);
-        }
-
         foreach ($nodes as $node) {
             $this->addNode($workspaceName, $node);
         }

--- a/tests/generate_fixtures.php
+++ b/tests/generate_fixtures.php
@@ -7,9 +7,6 @@
  */
 function generate_fixtures($srcDir, $destDir)
 {
-    $srcDom = new \Jackalope\Test\Fixture\JCRSystemXML(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'system.xml');
-    $systemNodes = $srcDom->load()->getNodes();
-
     foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($srcDir)) as $srcFile) {
         if (method_exists($srcFile, 'getExtension')) {
             $extension = $srcFile->getExtension();
@@ -33,7 +30,6 @@ function generate_fixtures($srcDir, $destDir)
         $destDom->addWorkspace('tests');
         $destDom->addNamespaces($srcDom->getNamespaces());
         $destDom->addNodes('tests', $nodes);
-        $destDom->addNodes('tests', $systemNodes);
         // delay this to the end to not add entries for weak refs to not existing nodes
         $destDom->addReferences();
         $destDom->save();

--- a/tests/generate_fixtures.php
+++ b/tests/generate_fixtures.php
@@ -7,6 +7,9 @@
  */
 function generate_fixtures($srcDir, $destDir)
 {
+    $srcDom = new \Jackalope\Test\Fixture\JCRSystemXML(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'system.xml');
+    $systemNodes = $srcDom->load()->getNodes();
+
     foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($srcDir)) as $srcFile) {
         if (method_exists($srcFile, 'getExtension')) {
             $extension = $srcFile->getExtension();
@@ -30,6 +33,7 @@ function generate_fixtures($srcDir, $destDir)
         $destDom->addWorkspace('tests');
         $destDom->addNamespaces($srcDom->getNamespaces());
         $destDom->addNodes('tests', $nodes);
+        $destDom->addNodes('tests', $systemNodes);
         // delay this to the end to not add entries for weak refs to not existing nodes
         $destDom->addReferences();
         $destDom->save();


### PR DESCRIPTION
This PR adds a call to the restore method of the `VersionHandler` in jackalope/jackalope 

Needs https://github.com/jackalope/jackalope/pull/289 and https://github.com/phpcr/phpcr/pull/93
It also uses the tests added at https://github.com/phpcr/phpcr-api-tests/pull/160
