### PR TITLE
make it possible to create and reference nodes within a single transaction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         "doctrine/dbal": ">=2.4.5,<3.0.x-dev",
         "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "^1.2.8",
-        "jackalope/jackalope": "~1.2.2"
+        "jackalope/jackalope": "~1.2.4"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"
     },
     "require-dev": {
         "psr/log": "~1.0",
-        "phpcr/phpcr-api-tests": "2.1.9",
+        "phpcr/phpcr-api-tests": "2.1.10",
         "phpunit/phpunit": "4.7.*",
         "phpunit/dbunit": "~1.3"
     },

--- a/tests/Jackalope/Test/TestCase.php
+++ b/tests/Jackalope/Test/TestCase.php
@@ -4,8 +4,9 @@ namespace Jackalope\Test;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Jackalope\TestCase as BaseTestCase;
 
-abstract class TestCase extends \Jackalope\TestCase
+abstract class TestCase extends BaseTestCase
 {
     /**
      * @var Connection


### PR DESCRIPTION
see https://github.com/phpcr/phpcr-api-tests/pull/165

while investigating #287 I stumbled over this issue.

according to http://stackoverflow.com/questions/7474222/jackrabbit-node-getreferences-not-returning-anything it should be possible to create and reference nodes within a single transaction. however it seems like we create the uuid too late and so when we have the Operations we point to the path and not the UUID, which then prevents us from finding out the system id when we create the references.