### PR TITLE
fix copy children binary nodes data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "psr/log": "~1.0",
-        "phpcr/phpcr-api-tests": "2.1.6",
+        "phpcr/phpcr-api-tests": "dev-master",
         "phpunit/phpunit": "4.7.*",
         "phpunit/dbunit": "~1.3"
     },

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2187,7 +2187,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
     /**
      * {@inheritDoc}
-     * @throws RepositoryException then no binary data found
+     * @throws RepositoryException when no binary data found
      */
     public function getBinaryStream($path)
     {
@@ -2205,7 +2205,6 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         if (count($data) === 0) {
             throw new RepositoryException('No binary data found in stream');
         }
-
 
         $streams = array();
         foreach ($data as $row) {

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -695,7 +695,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                 '   SELECT ?, b.property_name, ?, b.idx, b.data FROM phpcr_binarydata b WHERE b.node_id = ?';
 
             try {
-                $this->getConnection()->executeUpdate($query, array($newNodeId, $this->workspaceName, $srcNodeId));
+                $this->getConnection()->executeUpdate($query, array($newNodeId, $this->workspaceName, $row['id']));
             } catch (DBALException $e) {
                 throw new RepositoryException("Unexpected exception while copying node from $srcAbsPath to $dstAbsPath", $e->getCode(), $e);
             }
@@ -2187,6 +2187,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
     /**
      * {@inheritDoc}
+     * @throws RepositoryException then no binary data found
      */
     public function getBinaryStream($path)
     {
@@ -2200,6 +2201,11 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
             'SELECT data, idx FROM phpcr_binarydata WHERE node_id = ? AND property_name = ? AND workspace_name = ?',
             array($nodeId, $propertyName, $this->workspaceName)
         );
+
+        if (count($data) === 0) {
+            throw new RepositoryException('No binary data found in stream');
+        }
+
 
         $streams = array();
         foreach ($data as $row) {


### PR DESCRIPTION
Fixed a bug with copying binary data of children nodes while doing Transport:copy.
Had also add a check in getBinaryStream() to make sure requested stream really exists.