### PR TITLE
update tests and skip date query test until implemented

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "psr/log": "~1.0",
-        "phpcr/phpcr-api-tests": "2.1.11",
+        "phpcr/phpcr-api-tests": "2.1.13",
         "phpunit/phpunit": "4.7.*",
         "phpunit/dbunit": "~1.3"
     },

--- a/tests/ImplementationLoader.php
+++ b/tests/ImplementationLoader.php
@@ -67,6 +67,8 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
                     'Query\\QueryManagerTest::testGetQuery',
                     'Query\\QueryManagerTest::testGetQueryInvalid',
                     'Query\\QueryObjectSql2Test::testGetStoredQueryPath',
+                    // TODO: implement CAST, see also https://github.com/jackalope/jackalope-doctrine-dbal/issues/267
+                    'Query\QuerySql2OperationsTest::testQueryFieldDate',
                     // TODO fix handling of order by with missing properties
                     'Query\QuerySql2OperationsTest::testQueryOrderWithMissingProperty',
 


### PR DESCRIPTION
testing https://github.com/phpcr/phpcr-api-tests/pull/176

CAST is not supported yet, see also #267. note that i tried without cast, just with the string, and that did not work either.