### PR TITLE
Replace all spaces with underscores in cache keys.

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -37,13 +37,14 @@ class CachedClient extends Client
 
         $caches['meta'] = isset($caches['meta']) ? $caches['meta'] : new ArrayCache();
         $this->caches = $caches;
-        $this->keySanitizer = function($cacheKey){ return str_replace(' ', '_', $cacheKey);};
+        $this->keySanitizer = function ($cacheKey) { return str_replace(' ', '_', $cacheKey);};
     }
 
     /**
      * @param \Closure $sanitizer
      */
-    public function setKeySanitizer(\Closure $sanitizer){
+    public function setKeySanitizer(\Closure $sanitizer)
+    {
         $this->keySanitizer = $sanitizer;
     }
 
@@ -67,8 +68,9 @@ class CachedClient extends Client
      *
      * @return mixed
      */
-    private function sanitizeKey($cacheKey){
-        if($sanitizer = $this->keySanitizer){
+    private function sanitizeKey($cacheKey)
+    {
+        if ($sanitizer = $this->keySanitizer) {
             return $sanitizer($cacheKey);
         }
         return $cacheKey;

--- a/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
@@ -7,9 +7,13 @@ use Jackalope\Test\FunctionalTestCase;
 
 class CachedClientTest extends FunctionalTestCase
 {
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    private $cacheMock;
+
     protected function getClient(Connection $conn)
     {
-        return new CachedClient(new \Jackalope\Factory(), $conn);
+        $this->cacheMock = $this->getMock('\Doctrine\Common\Cache\MemcachedCache');
+        return new CachedClient(new \Jackalope\Factory(), $conn, ['nodes' => $this->cacheMock, 'meta' => $this->cacheMock]);
     }
 
     public function testArrayObjectIsConvertedToArray()
@@ -17,5 +21,41 @@ class CachedClientTest extends FunctionalTestCase
         $namespaces = $this->transport->getNamespaces();
 
         $this->assertInternalType("array", $namespaces);
+    }
+
+    /**
+     * The default key sanitizer replaces spaces with underscores
+     */
+    public function testDefaultKeySanitizer(){
+        $this->cacheMock
+            ->expects($this->at(0))
+            ->method('fetch')
+            ->with(
+                $this->equalTo('nodetypes:_a:0:{}')
+            );
+
+        /** @var CachedClient $cachedClient */
+        $cachedClient = $this->transport;
+        $cachedClient->getNodeTypes();
+    }
+
+    public function testCustomkeySanitizer(){
+        /** @var CachedClient $cachedClient */
+        $cachedClient = $this->transport;
+        //set a custom sanitizer that reveres the cachekey
+        $cachedClient->setKeySanitizer(function($cacheKey){
+            return strrev($cacheKey);
+        });
+
+        $this->cacheMock
+            ->expects($this->at(0))
+            ->method('fetch')
+            ->with(
+                $this->equalTo('}{:0:a :sepytedon')
+            );
+
+        /** @var CachedClient $cachedClient */
+        $cachedClient = $this->transport;
+        $cachedClient->getNodeTypes();
     }
 }

--- a/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
@@ -13,7 +13,7 @@ class CachedClientTest extends FunctionalTestCase
     protected function getClient(Connection $conn)
     {
         $this->cacheMock = $this->getMock('\Doctrine\Common\Cache\MemcachedCache');
-        return new CachedClient(new \Jackalope\Factory(), $conn, ['nodes' => $this->cacheMock, 'meta' => $this->cacheMock]);
+        return new CachedClient(new \Jackalope\Factory(), $conn, array('nodes' => $this->cacheMock, 'meta' => $this->cacheMock));
     }
 
     public function testArrayObjectIsConvertedToArray()
@@ -26,7 +26,8 @@ class CachedClientTest extends FunctionalTestCase
     /**
      * The default key sanitizer replaces spaces with underscores
      */
-    public function testDefaultKeySanitizer(){
+    public function testDefaultKeySanitizer()
+    {
         $this->cacheMock
             ->expects($this->at(0))
             ->method('fetch')
@@ -39,11 +40,12 @@ class CachedClientTest extends FunctionalTestCase
         $cachedClient->getNodeTypes();
     }
 
-    public function testCustomkeySanitizer(){
+    public function testCustomkeySanitizer()
+    {
         /** @var CachedClient $cachedClient */
         $cachedClient = $this->transport;
         //set a custom sanitizer that reveres the cachekey
-        $cachedClient->setKeySanitizer(function($cacheKey){
+        $cachedClient->setKeySanitizer(function ($cacheKey) {
             return strrev($cacheKey);
         });
 

--- a/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
@@ -12,7 +12,7 @@ class CachedClientTest extends FunctionalTestCase
 
     protected function getClient(Connection $conn)
     {
-        $this->cacheMock = $this->getMock('\Doctrine\Common\Cache\MemcachedCache');
+        $this->cacheMock = $this->getMock('\Doctrine\Common\Cache\ArrayCache');
         return new CachedClient(new \Jackalope\Factory(), $conn, array('nodes' => $this->cacheMock, 'meta' => $this->cacheMock));
     }
 


### PR DESCRIPTION
When using MemcachedCache, the CachedClient can not save results to the cache, because the keys contain whitespace.
This change adds a 'sanitizer' function that replaces the spaces with underscores. This function can be changed  when using another cache backend that has other key requirements.