### PR TITLE
Invalid state when node is deleted in a different session.

### DIFF
--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -30,6 +30,29 @@ class ClientTest extends FunctionalTestCase
         $this->assertEquals(1, count($result->getNodes()));
     }
 
+    /**
+     * If the node was deleted in another session and we refresh the session
+     * what should happen?
+     */
+    public function testRefreshWithDeletedNodes()
+    {
+        $root = $this->session->getNode('/');
+        $article = $root->addNode('article');
+        $article->setProperty('foo', 'bar');
+        $article->setProperty('bar', 'baz');
+        $article->setProperty('bar', 'baz');
+        $this->session->save();
+
+        // simulate node being deleted in another session.
+        $nbRows = $this->getConnection()->exec('DELETE FROM phpcr_nodes WHERE path="/article"');
+        $this->assertEquals(1, $nbRows);
+
+        $this->session->refresh(false);
+
+        // throws PathNotFoundException
+        $article->getProperty('foo');
+    }
+
     public function testAddNodeTypes()
     {
         $workspace = $this->session->getWorkspace();


### PR DESCRIPTION
We have encountered problems with the new DoctrinePHPCRBundle when it shuts down the kernel. It calls "clean" on the document manager and then logs out of the session(s).

The problem is that calling "clean" invokes a `refresh(false)` and in our test cases it may be that some of the nodes managed in the current kernel have been deleted from storage in another, so our system explodes with:

```
PHPCR\InvalidItemStateException: Item /article is deleted
```

when the kernel is shutdown.

I think that in this case nodes should be de-registered (and so accessing them would throw a "node deleted" error) - 

if you `refresh($keepChanges = false)` and this is the case, it means that you may encounter this error later rather than sooner (mostly never) - not sure if that is better or worse tbh.

We could also address this in the Bundle somehow.
