### PR TITLE
Do not change TZ of \DateTime assoc. with Node

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1157,6 +1157,10 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                     }
                     foreach ((array) $values as $key => $date) {
                         if ($date instanceof \DateTime) {
+                            // do not modify the instance which is associated with the node.
+                            $date = clone $date;
+
+                            // normalize to UTC for storage.
                             $date->setTimezone(new \DateTimeZone('UTC'));
                         }
                         $values[$key] = $date;

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -525,4 +525,20 @@ class ClientTest extends FunctionalTestCase
         $this->assertEquals($child1['props'], $child2['props']);
         $this->assertEquals($child1['numerical_props'], $child2['numerical_props']);
     }
+
+    /**
+     * The date value should not change when saving.
+     */
+    public function testDate()
+    {
+        $rootNode = $this->session->getNode('/');
+        $child1 = $rootNode->addNode('child1');
+        $date = new \DateTime();
+        $before = $date->format('c');
+        $child1->setProperty('date', $date);
+        $this->session->save();
+        $after = $date->format('c');
+
+        $this->assertEquals($before, $after);
+    }
 }


### PR DESCRIPTION
The current code "normalizes to UTC for storage and uses the system timezone on hydration" according to this PR:

https://github.com/jackalope/jackalope-doctrine-dbal/pull/109

But this means that the \DateTime object we have before `$session->save()` is not equivilent to the date time object we have after, which is inconsistent.

This PR clones the \DateTime object before normalizing it to UTC for storage.