### PR TITLE
Use multiple field comparator for sqlite and other DBs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "psr/log": "~1.0",
-        "phpcr/phpcr-api-tests": "2.1.14",
+        "phpcr/phpcr-api-tests": "2.1.15",
         "phpunit/phpunit": "4.7.*",
         "phpunit/dbunit": "~1.3"
     },

--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -690,6 +690,10 @@ class QOMWalker
             );
         }
 
+        if ('=' === $operator) {
+            return $this->sqlXpathComparePropertyValue($alias, $property, $literalOperand->getLiteralValue(), $operator);
+        }
+
         return sprintf(
             '%s %s %s',
             $this->sqlXpathExtractNumValue($alias, $property),


### PR DESCRIPTION
Only MySQL currently supports comparison of multiple value fields with numerical properties.

This PR applies the same logic that we have for strings for numbers in other implementations other than MySQL.