### PR TITLE
Fixed issue for copy when name starts equally

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -37,7 +37,9 @@ class CachedClient extends Client
 
         $caches['meta'] = isset($caches['meta']) ? $caches['meta'] : new ArrayCache();
         $this->caches = $caches;
-        $this->keySanitizer = function ($cacheKey) { return str_replace(' ', '_', $cacheKey);};
+        $this->keySanitizer = function ($cacheKey) {
+            return str_replace(' ', '_', $cacheKey);
+        };
     }
 
     /**

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -619,8 +619,8 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         // 4. if a reference is in the properties, either update the uuid based on the map if its inside the copied graph or keep it.
         // 5. "May drop mixin types"
 
-        $query = 'SELECT * FROM phpcr_nodes WHERE path LIKE ? AND workspace_name = ?';
-        $stmt = $this->getConnection()->executeQuery($query, array($srcAbsPath . '%', $srcWorkspace));
+        $query = 'SELECT * FROM phpcr_nodes WHERE (path = ? OR path LIKE ?) AND workspace_name = ?';
+        $stmt = $this->getConnection()->executeQuery($query, array($srcAbsPath, $srcAbsPath . '/%', $srcWorkspace));
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
 
         $uuidMap = array();

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -526,6 +526,37 @@ class ClientTest extends FunctionalTestCase
         $this->assertEquals($child1['numerical_props'], $child2['numerical_props']);
     }
 
+    public function testCopySiblingWithSamePrefix()
+    {
+        $rootNode = $this->session->getNode('/');
+        $child1 = $rootNode->addNode('child1');
+        $child1->setProperty('string', 'Hello');
+        $child1->setProperty('number', 1234);
+        $child2 = $rootNode->addNode('child1-2');
+        $child2->setProperty('string', 'Hello');
+        $child2->setProperty('number', 1234);
+
+        $this->session->save();
+
+        $this->session->getWorkspace()->copy('/child1', '/child2');
+
+        $stmt = $this->conn->query("SELECT * FROM phpcr_nodes WHERE path LIKE '/child%'");
+        $children = $stmt->fetchAll();
+
+        $this->assertCount(3, $children);
+
+        $paths = array_map(
+            function ($child) {
+                return $child['path'];
+            },
+            $children
+        );
+
+        $this->assertContains('/child1', $paths);
+        $this->assertContains('/child2', $paths);
+        $this->assertContains('/child1-2', $paths);
+    }
+
     /**
      * The date value should not change when saving.
      */


### PR DESCRIPTION
This PR fixes an issue when copying a node and this node has siblings with names which starts equally.

Example:

* /page-1
* /page-1-1

copy `page-1` to `page-2`. Then the `page-1-1` will also be copied to `page-2-1`.

I have updated the query to select all nodes which has to be copied. This change was also be done before for the move method.

This PR also fixes sulu/sulu#2453 in sulu