### PR TITLE
change collation in query to adapt to charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.3.0
+-----
+
+* Added auto-detection of binary collation for MySQL, so that not always utf8_bin is used.
+  A new `setCaseSensitiveEncoding` method has been introduced, which can be used to override
+  the auto detected value.
+
 1.2
 ---
 

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -206,6 +206,11 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     private $nodeProcessor;
 
     /**
+     * @var string
+     */
+    private $caseSensitiveEncoding;
+
+    /**
      * @param FactoryInterface $factory
      * @param Connection       $conn
      */
@@ -437,6 +442,34 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     public function setCheckLoginOnServer($bool)
     {
         $this->checkLoginOnServer = $bool;
+    }
+
+    /**
+     * This will control the collate which is being used on MySQL when querying nodes. It will be autodetected by just
+     * appending _bin to the current charset, which is good enough in most cases.
+     *
+     * @param string $encoding
+     */
+    public function setCaseSensitiveEncoding($encoding)
+    {
+        $this->caseSensitiveEncoding = $encoding;
+    }
+
+    /**
+     * Returns the collate which is being used on MySQL when querying nodes.
+     *
+     * @return string
+     */
+    private function getCaseSensitiveEncoding()
+    {
+        if (!$this->caseSensitiveEncoding) {
+            $params = $this->conn->getParams();
+            $charset = isset($params['charset']) ? $params['charset'] : 'utf8';
+
+            return $this->caseSensitiveEncoding = $charset === 'binary' ? $charset : $charset . '_bin';
+        }
+
+        return $this->caseSensitiveEncoding;
     }
 
     protected function workspaceExists($workspaceName)
@@ -1540,7 +1573,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
             $query = 'SELECT id FROM phpcr_nodes WHERE identifier = ? AND workspace_name = ?';
         } else {
             if ($this->getConnection()->getDriver() instanceof \Doctrine\DBAL\Driver\PDOMySql\Driver) {
-                $query = 'SELECT id FROM phpcr_nodes WHERE path COLLATE utf8_bin = ? AND workspace_name = ?';
+                $query = 'SELECT id FROM phpcr_nodes WHERE path COLLATE ' . $this->getCaseSensitiveEncoding() .' = ? AND workspace_name = ?';
             } else {
                 $query = 'SELECT id FROM phpcr_nodes WHERE path = ? AND workspace_name = ?';
             }


### PR DESCRIPTION
This change is related to https://github.com/doctrine/DoctrinePHPCRBundle/pull/270. If a connection to the [RepositorySchema](https://github.com/jackalope/jackalope-doctrine-dbal/blob/75bfb54453f224a9e848cee70cc85bf8d48c4556/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php#L37) with a charset of `utf8mb4` is passed it is not allowed to use `utf8_bin` in a select statement.

I simply changed it in here to `utf8mb4_bin`, which will work then. However, I know that this can't be the final solution. The question is how that one should look like. We could use the `connection` to get the charset and use an if in here, or use the charset and simply postfix it with `_bin`, maybe check before if this collation really exists (is that somehow possible? What should be done in case it isn't?).