### PR TITLE
Fixing issue where dates comparisons doesn't work

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -850,7 +850,16 @@ class QOMWalker
     {
         $value = $operand->getLiteralValue();
 
-        return $value instanceof \DateTime ? $value->format('c') : $value;
+        /**
+         * Normalize Dates to UTC
+         */
+        if($value instanceof \DateTime){
+            $valueUTC = clone($value);
+            $valueUTC->setTimezone(new \DateTimeZone('UTC'));
+            return $valueUTC->format('c');
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
We use the PHPCR with MySQL for the Content Management System for one of our clients.
Some of the data is time dependent, and will only show up on the Website after a certain publish date.
The same code worked when using Jackrabbit as the persistent layer, but when using MySQL we noticed that DateTime comparisons were buggy.  

Overview:

- The DateTime objects get saved in the database in UTC Format
- When a Query has a comparison with a DateTime, it uses the QOMWalker::walkComparisonConstraint function.  There are special handling for Boolean and Numeric types, however, DateTime objects get passed to the walkTextComparisonConstraint function. 
- The walkTextComparisonConstraint then calls the getLiteralValue function, which serializes the DateTime object as a ISO-8601 format.
- The resultant SQL query that is sent to the database is a string comparison on the serialized dates.

Sample SQL Fragment...
EXTRACTVALUE(n0.props, 'count(//sv:property[@sv:name="publishDate"]/sv:value[text()<="2017-01-30T19:47:56-08:00"]) > 0') 

However, I don't think the ISO-8601 format isn't a good format to do string comparisons because of the TimeZone offset (which follows the +/- at the end of the string).

Example:

10 AM in UTC
2017-01-30T10:00:00+00:00

Which is equivalent to 2AM San Diego/Los Angeles time (since we in San Diego are 8 hours behind UTC).
2017-01-30T02:00:00-08:00

A simple string comparison of these DateTime strings will result in falsely asserting that 2AM San Diego time is before 10AM UTC.

This pull request normalizes all dates to UTC before serializing and forming the SQL Query.  Because all DateTimes are already in the database as UTC, this fixed the bug for us.




















