### PR TITLE
user node types optimization

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -212,6 +212,11 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     private $caseSensitiveEncoding;
 
     /**
+     * @var array
+     */
+    private $userNodeTypes;
+
+    /**
      * @param FactoryInterface $factory
      * @param Connection       $conn
      */
@@ -2104,14 +2109,16 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     {
         $standardTypes = StandardNodeTypes::getNodeTypeData();
 
-        $userTypes = $this->fetchUserNodeTypes();
+        if ($this->userNodeTypes === null) {
+            $this->userNodeTypes = $this->fetchUserNodeTypes();
+        }
 
         if ($nodeTypes) {
             $nodeTypes = array_flip($nodeTypes);
-            return array_values(array_intersect_key($standardTypes, $nodeTypes) + array_intersect_key($userTypes, $nodeTypes));
+            return array_values(array_intersect_key($standardTypes, $nodeTypes) + array_intersect_key($this->userNodeTypes, $nodeTypes));
         }
 
-        return array_values($standardTypes + $userTypes);
+        return array_values($standardTypes + $this->userNodeTypes);
     }
 
     /**


### PR DESCRIPTION
I added caching user node types to avoid querying in every getNodeTypes method call.

Before:
![snimek obrazovky 2017-02-26 v 22 50 29](https://cloud.githubusercontent.com/assets/7081340/23381171/c73174b0-fd3d-11e6-9f39-bca53d68a029.png)

After:
![snimek obrazovky 2017-02-26 v 22 50 59](https://cloud.githubusercontent.com/assets/7081340/23381182/d294a02a-fd3d-11e6-8635-3ac955da354b.png)

@danrot can you test it on Sulu, please? Thank you :)
