### PR TITLE
Add support for utf8mb4

### DIFF
--- a/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
+++ b/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
@@ -84,7 +84,7 @@ EOT
             return self::RETURN_CODE_NO_FORCE;
         }
 
-        $schema = new RepositorySchema;
+        $schema = new RepositorySchema([], $connection);
 
         try {
             if ($input->getOption('drop')) {

--- a/tests/Jackalope/Tools/Console/InitDoctrineDbalCommandTest.php
+++ b/tests/Jackalope/Tools/Console/InitDoctrineDbalCommandTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
 class InitDoctrineDbalCommandTest extends TestCase
 {
@@ -30,6 +31,11 @@ class InitDoctrineDbalCommandTest extends TestCase
     protected $platform;
 
     /**
+     * @var AbstractSchemaManager
+     */
+    protected $schemaManager;
+
+    /**
      * @var Application
      */
     protected $application;
@@ -37,6 +43,10 @@ class InitDoctrineDbalCommandTest extends TestCase
     public function setUp()
     {
         $this->connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->schemaManager = $this->getMockBuilder(AbstractSchemaManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -48,6 +58,16 @@ class InitDoctrineDbalCommandTest extends TestCase
             ->expects($this->any())
             ->method('getDatabasePlatform')
             ->will($this->returnValue($this->platform));
+
+        $this->schemaManager
+            ->expects($this->any())
+            ->method('createSchemaConfig')
+            ->will($this->returnValue(null));
+
+        $this->connection
+            ->expects($this->any())
+            ->method('getSchemaManager')
+            ->will($this->returnValue($this->schemaManager));
 
         $this->helperSet = new HelperSet([
             'phpcr' => new DoctrineDbalHelper($this->connection),


### PR DESCRIPTION
When using the following configuration for doctrine based on [Symfony 3.4 recommandation](https://symfony.com/doc/3.4/doctrine.html#configuring-the-database):

```yaml
doctrine:
    dbal:
        driver:   "%database_driver%"
        host:     "%database_host%"
        port:     "%database_port%"
        dbname:   "%database_name%"
        user:     "%database_user%"
        password: "%database_password%"
        server_version: "%database_version%"
        charset: utf8mb4
        default_table_options:
            charset: utf8mb4
            collate: utf8mb4_unicode_ci
```

The database fail because the index key is too long. From the official docs the keys should not be longer then 191 because utf8mb4 needs 4 bytes instead of the 3 byte per character.  https://dev.mysql.com/doc/refman/5.6/en/charset-unicode-conversion.html

Tested with: MySQL 5.6.21 on OSX. To avoid a BC Break it only will set the length to 191 when utf8mb4 is used.

<details>
  <summary>
Error message which did appears before this changes:</summary>

```bash
In ToolsException.php line 39:

          Schema-Tool failed with Error 'An exception occurred while
           executing 'CREATE TABLE phpcr_namespaces (prefix VARCHAR(
          192) NOT NULL, uri VARCHAR(255) NOT NULL, PRIMARY KEY(pref
          ix)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode
          _ci ENGINE = InnoDB':

          SQLSTATE[42000]: Syntax error or access violation: 1071 Sp
          ecified key was too long; max key length is 767 bytes' whi
          le executing DDL: CREATE TABLE phpcr_namespaces (prefix VA
          RCHAR(192) NOT NULL, uri VARCHAR(255) NOT NULL, PRIMARY KE
          Y(prefix)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_u
          nicode_ci ENGINE = InnoDB


        In AbstractMySQLDriver.php line 115:

          An exception occurred while executing 'CREATE TABLE phpcr_
          namespaces (prefix VARCHAR(192) NOT NULL, uri VARCHAR(255)
           NOT NULL, PRIMARY KEY(prefix)) DEFAULT CHARACTER SET utf8
          mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB':

          SQLSTATE[42000]: Syntax error or access violation: 1071 Sp
          ecified key was too long; max key length is 767 bytes


        In PDOConnection.php line 106:

          SQLSTATE[42000]: Syntax error or access violation: 1071 Sp
          ecified key was too long; max key length is 767 bytes


        In PDOConnection.php line 104:

          SQLSTATE[42000]: Syntax error or access violation: 1071 Sp
          ecified key was too long; max key length is 767 bytes
```
</details>