### PR TITLE
MySQL utf8mb4 limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3.1
+-----
+
+* Detect utf8mb4 encoding and use shorter fields so MySQL can handle indexes on 4 byte UTF-8.
+
 1.3.0
 -----
 

--- a/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
+++ b/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
@@ -84,7 +84,7 @@ EOT
             return self::RETURN_CODE_NO_FORCE;
         }
 
-        $schema = new RepositorySchema;
+        $schema = new RepositorySchema([], $connection);
 
         try {
             if ($input->getOption('drop')) {

--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -24,7 +24,7 @@ class RepositorySchema extends Schema
     /**
      * @var integer
      */
-    private $maxIndexLength;
+    private $maxIndexLength = -1;
 
     /**
      * @param array $options The options could be use to make the table
@@ -225,19 +225,24 @@ class RepositorySchema extends Schema
         }
     }
 
-    private function getMaxIndexLength($currentMaxLength = 255)
+    private function getMaxIndexLength($currentMaxLength = null)
     {
-        if (null !== $this->maxIndexLength) {
-            return $currentMaxLength < $this->maxIndexLength ? $currentMaxLength : $this->maxIndexLength;
+        if (-1 === $this->maxIndexLength) {
+            $this->maxIndexLength = null;
+
+            if ($this->isConnectionCharsetUtf8mb4()) {
+                $this->maxIndexLength = 191;
+            }
         }
 
-        $this->maxIndexLength = 255;
-
-        if ($this->isConnectionCharsetUtf8mb4()) {
-            $this->maxIndexLength = 191;
+        if ($currentMaxLength && (
+            null === $this->maxIndexLength
+            || $currentMaxLength < $this->maxIndexLength
+        )) {
+            return $currentMaxLength;
         }
-
-        return $currentMaxLength < $this->maxIndexLength ? $currentMaxLength : $this->maxIndexLength;
+        
+        return $this->maxIndexLength;
     }
 
     private function isConnectionCharsetUtf8mb4()

--- a/tests/Jackalope/Tools/Console/InitDoctrineDbalCommandTest.php
+++ b/tests/Jackalope/Tools/Console/InitDoctrineDbalCommandTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
 class InitDoctrineDbalCommandTest extends TestCase
 {
@@ -30,6 +31,11 @@ class InitDoctrineDbalCommandTest extends TestCase
     protected $platform;
 
     /**
+     * @var AbstractSchemaManager
+     */
+    protected $schemaManager;
+
+    /**
      * @var Application
      */
     protected $application;
@@ -37,6 +43,10 @@ class InitDoctrineDbalCommandTest extends TestCase
     public function setUp()
     {
         $this->connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->schemaManager = $this->getMockBuilder(AbstractSchemaManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -48,6 +58,16 @@ class InitDoctrineDbalCommandTest extends TestCase
             ->expects($this->any())
             ->method('getDatabasePlatform')
             ->will($this->returnValue($this->platform));
+
+        $this->schemaManager
+            ->expects($this->any())
+            ->method('createSchemaConfig')
+            ->will($this->returnValue(null));
+
+        $this->connection
+            ->expects($this->any())
+            ->method('getSchemaManager')
+            ->will($this->returnValue($this->schemaManager));
 
         $this->helperSet = new HelperSet([
             'phpcr' => new DoctrineDbalHelper($this->connection),


### PR DESCRIPTION
MySQL implemented utf8 support without 4 byte characters and added the utf8mb4 encoding to work around the issue. Indexes for utf8mb4 can not be more than 191 characters.

Postgres is not affected as they implemented full utf8 from the beginning. I did not find anything about this for sqlite, but assume for now that its also not affected.