### PR TITLE
[BUG FIX] Fix wrong return type.

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -203,7 +203,7 @@ class CachedClient extends Client
             $this->caches['meta']->save($cacheKey, $result);
         }
 
-        return $result;
+        return (array) $result;
     }
 
     /**


### PR DESCRIPTION
Force to return `array` instead of `ArrayObject` (`getNamespaces` need to return `array` by design).

https://github.com/jackalope/jackalope-doctrine-dbal/blob/058cd85e4c571f475250ad2e76d17b97feccdc75/src/Jackalope/Transport/DoctrineDBAL/Client.php#L580-L583
