### PR TITLE
Fix reordering of namespaced children fails

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2038,7 +2038,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         $i = 0;
 
         foreach ($node->getNodeNames() as $name) {
-            $values[':name' . $i] = $name;
+            $values[':name' . $i] = implode(':', array_filter($this->getJcrName($name)));
             $values[':order' . $i] = $i; // use our counter to avoid gaps
             $sql .= " WHEN :name$i THEN :order$i";
             $i++;

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -160,8 +160,8 @@ class DBUnitFixtureXML extends XMLDocument
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         $phpcrNode = $dom->createElement('sv:node');
-        foreach ($this->namespaces as $namespace => $uri) {
-            $phpcrNode->setAttribute('xmlns:' . $namespace, $uri);
+        foreach ($this->namespaces as $namespacePrefix => $uri) {
+            $phpcrNode->setAttribute('xmlns:' . $namespacePrefix, $uri);
         }
         $dom->appendChild($phpcrNode);
 
@@ -179,21 +179,20 @@ class DBUnitFixtureXML extends XMLDocument
 
         list($parentPath, $childPath) = $this->getPath($node);
 
-        $namespace  = '';
+        $namespacePrefix  = '';
         $name       = $node->getAttributeNS($this->namespaces['sv'], 'name');
         if (count($parts = explode(':', $name, 2)) === 2) {
-            list($namespace, $name) = $parts;
+            list($namespacePrefix, $name) = $parts;
         }
 
-        if ($namespace === 'jcr' && $name === 'root') {
+        $namespace = isset($this->namespaces[$namespacePrefix]) ? $this->namespaces[$namespacePrefix] : '';
+
+        if ($namespacePrefix === 'jcr' && $name === 'root') {
             $id         = 1;
             $childPath  = '/';
             $parentPath = '';
             $name       = '';
             $namespace  = '';
-        }
-        if (isset($this->namespaces[$namespace])) {
-            $namespace = $this->namespaces[$namespace];
         }
 
         $this->addRow('phpcr_nodes', [

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -192,6 +192,9 @@ class DBUnitFixtureXML extends XMLDocument
             $name       = '';
             $namespace  = '';
         }
+        if (isset($this->namespaces[$namespace])) {
+            $namespace = $this->namespaces[$namespace];
+        }
 
         $this->addRow('phpcr_nodes', [
             'id'            => $id,


### PR DESCRIPTION
We are running into an issue where reordering namespaced nodes fails because of the following issue:

When you have 2 namespaced nodes under the same parent `Client::reorderChildren` is trying to sort them by concatenating namespace and nodename, the namespace in de nodes table is stored as the uri of the namespace instead of the prefix (namespace table primary key). In several locations in the client the uri is fetched and used for nodes queries, but in the reorder is it not.

The related api test in OrderBeforeTest::testNodeOrderNamespaces passed because the `DBUnitFixturesXML` was importing the prefix into the namespace instead of the uri (as the library is doing).

Fixing both Client and import now passes these tests and ensures namespaced nodes get reordered as expected