### PR TITLE
Fix join with multiple referenced documents generating wrong join conditions

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -427,20 +427,17 @@ class QOMWalker
         if ($condition instanceof QOM\ChildNodeJoinConditionInterface) {
             return $this->walkChildNodeJoinCondition($condition);
         }
-
         if ($condition instanceof QOM\DescendantNodeJoinConditionInterface) {
             return $this->walkDescendantNodeJoinCondition($condition);
         }
-
         if ($condition instanceof QOM\EquiJoinConditionInterface) {
             if ($left instanceof QOM\SelectorInterface) {
                 $selectorName = $left->getSelectorName();
             } else {
-                $selectorName = $this->getRightJoinSelector($left->getJoinCondition());
+                $selectorName = $this->getLeftJoinSelector($this->getLeftMostJoin($left)->getJoinCondition());
             }
             return $this->walkEquiJoinCondition($selectorName, $right->getSelectorName(), $condition);
         }
-
         if ($condition instanceof QOM\SameNodeJoinConditionInterface) {
             throw new NotImplementedException('SameNodeJoinCondtion');
         }


### PR DESCRIPTION
Hi,

this fix relates to the recent PR https://github.com/jackalope/jackalope-doctrine-dbal/pull/364

when joining multiple referenced documents to the main document it fails
but here the on clause of the 2nd join generated would be referencing an invalid alias of the first join instead of the main document `EXTRACTVALUE(n1.props, '//sv:property[@sv:name="group"]/sv:value[1]') = n2.identifier`

```php
INNER JOIN phpcr_nodes n1 ON ...  AND EXTRACTVALUE(n0.props, '//sv:property[@sv:name="category"]/sv:value[1]') = n1.identifier )
​
INNER JOIN phpcr_nodes n2 ON ... AND EXTRACTVALUE(n1.props, '//sv:property[@sv:name="group"]/sv:value[1]') = n2.identifier )
```

where you would expect it to be

```php
INNER JOIN phpcr_nodes n1 ON ...  AND EXTRACTVALUE(n0.props, '//sv:property[@sv:name="category"]/sv:value[1]') = n1.identifier )
​
INNER JOIN phpcr_nodes n2 ON ... AND EXTRACTVALUE(n0.props, '//sv:property[@sv:name="group"]/sv:value[1]') = n2.identifier )
```
