### PR TITLE
Avoid deprecation warning on PHP 7.4

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1998,7 +1998,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
             return;
         }
 
-        $ids = implode($ids, ',');
+        $ids = implode(',', $ids);
 
         $updateLocalNameCase .= 'ELSE local_name END, ';
         $updateSortOrderCase .= 'ELSE sort_order END ';


### PR DESCRIPTION
On PHP 7.4 I get the following warning:

> PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in ~/Sulu/sulu-develop.localhost/vendor/sulu/sulu/vendor/jackalope/jackalope-doctrine-dbal/src/Jackalope/Transport/DoctrineDBAL/Client.php on line 2001