### PR TITLE
Fix move with namespaced nodes

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1983,7 +1983,8 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
             $updateDepthCase .= "WHEN id = :id$i THEN CAST(:depth$i AS $intType) ";
 
             if ($srcAbsPath === $row['path']) {
-                $values[':localname' . $i] = PathHelper::getNodeName($values[':path' . $i]);
+                list($namespace, $localName) = $this->getJcrName($values[':path' . $i]);
+                $values[':localname' . $i] = $localName;
 
                 $updateLocalNameCase .= "WHEN id = :id$i THEN :localname$i ";
                 $updateSortOrderCase .= "WHEN id = :id$i THEN (SELECT * FROM ( SELECT MAX(x.sort_order) + 1 FROM phpcr_nodes x WHERE x.parent = :parent$i) y) ";

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -345,6 +345,39 @@ class ClientTest extends FunctionalTestCase
         }
     }
 
+    public function testMoveNamespacedNodes()
+    {
+        $root = $this->session->getNode('/');
+        $topic1 = $root->addNode('jcr:topic1');
+        $topic1->addNode('jcr:thisisanewnode');
+        $topic1->addNode('jcr:topic1Child');
+
+        $this->session->save();
+        $this->session->move('/jcr:topic1', '/jcr:topic2');
+
+        $this->session->save();
+
+        $conn = $this->getConnection();
+        $qb = $conn->createQueryBuilder();
+
+        $qb->select('local_name')
+            ->from('phpcr_nodes', 'n')
+            ->where('n.path = :path')->andWhere('n.local_name = :local_name');
+
+        $query = $qb->getSql();
+
+        $expectedData = [
+            '/jcr:topic2' => 'topic2',
+            '/jcr:topic2/jcr:thisisanewnode' => 'thisisanewnode',
+            '/jcr:topic2/jcr:topic1Child' => 'topic1Child'
+        ];
+        foreach ($expectedData as $path => $localName) {
+            $stmnt = $this->conn->executeQuery($query, ['path' => $path, 'local_name' => $localName]);
+            $row = $stmnt->fetch();
+            $this->assertNotFalse($row, $path . ' with local_name' . $localName . ' does not exist in database');
+        }
+    }
+
     public function testCaseInsensativeRename()
     {
         $root = $this->session->getNode('/');


### PR DESCRIPTION
Hi @dbu me **again** :)

When you currently move a namespace'd node, the query build will change the local_name to the local_name including namespace while everywhere else it is stored without the namespace.

I've added a test first to prove current implementation is broken and the follow-up commit shows its now working as expected.

Thanks again for making time to review this!