### PR TITLE
feat(primary key): add missing primary key for phpcr_type_childs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.5.0
+-----
+
+* Fix add primary keys to all tables (https://www.percona.com/doc/percona-xtradb-cluster/LATEST/features/pxc-strict-mode.html#tables-without-primary-keys)
+
 1.4.1
 -----
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,14 @@
 Upgrade
 =======
 
+1.5
+---
+
+- The following change needs to be made to your database: 
+
+  `ALTER TABLE phpcr_type_childs ADD COLUMN `id` INT(11) UNSIGNED PRIMARY KEY AUTO_INCREMENT FIRST;` 
+  
+
 1.2
 ---
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@ Upgrade
 1.5
 ---
 
-- The following change needs to be made to your database: 
+- If you want to start using Percona in strict mode, or use the Percona cluster, add a primary key to the phpcr_type_childs:
 
   `ALTER TABLE phpcr_type_childs ADD COLUMN `id` INT(11) UNSIGNED PRIMARY KEY AUTO_INCREMENT FIRST;` 
   

--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -198,6 +198,7 @@ class RepositorySchema extends Schema
     protected function addTypeChildsTable()
     {
         $childTypes = $this->createTable('phpcr_type_childs');
+        $childTypes->addColumn('id', 'integer', ['autoincrement' => true]);
         $childTypes->addColumn('node_type_id', 'integer');
         $childTypes->addColumn('name', 'string');
         $childTypes->addColumn('protected', 'boolean');
@@ -206,6 +207,7 @@ class RepositorySchema extends Schema
         $childTypes->addColumn('on_parent_version', 'integer');
         $childTypes->addColumn('primary_types', 'string');
         $childTypes->addColumn('default_type', 'string', ['notnull' => false]);
+        $childTypes->setPrimaryKey(['id']);
     }
 
     public function reset()
@@ -241,7 +243,7 @@ class RepositorySchema extends Schema
         )) {
             return $currentMaxLength;
         }
-        
+
         return $this->maxIndexLength;
     }
 


### PR DESCRIPTION
If settings for percona or strict it requires a primary key on each table. To be backwards compatible we added a primary key on a new field, so there won't be breaking changes.