### PR TITLE
prevent type error on Postgresql

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -2700,6 +2700,11 @@ phpcr_type_childs ON phpcr_type_nodes.node_type_id = phpcr_type_childs.node_type
     private function getNodeReferences($path, $name = null, $weakReference = false)
     {
         $targetId = $this->getSystemIdForNode($path);
+
+        if (false === $targetId) {
+            return [];
+        }
+
         $params = [$targetId];
 
         $table = $weakReference ? $this->referenceTables[PropertyType::WEAKREFERENCE] : $this->referenceTables[PropertyType::REFERENCE];


### PR DESCRIPTION
Prevent a cast error on Postgresql when no target is found for the given path. This by adding an early return of an empty array. MySQL and possibly other databases would cast the false value to 0, after which the query result would still be an enpty array as no node can have a target_id equaling 0.