### PR TITLE
Add support for dbal 3 (and php 8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cli-config.php
+.phpunit.result.cache
 
 test-reports
 .buildpath

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - nightly
-
-sudo: false
 
 env:
   - DB=mysql
@@ -25,11 +22,11 @@ cache:
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.3
       env: DB=mysql COMPOSER_OPTIONS=--prefer-lowest --prefer-stable
-    - php: 7.1
+    - php: 7.3
       env: DB=pgsql COMPOSER_OPTIONS=--prefer-lowest --prefer-stable
-    - php: 7.1
+    - php: 7.3
       env: DB=sqlite COMPOSER_OPTIONS=--prefer-lowest --prefer-stable
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -15,23 +15,23 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.9.3",
+        "doctrine/dbal": "^2.11 || ^3.0",
         "phpcr/phpcr": "~2.1.5",
-        "phpcr/phpcr-utils": "^1.4.1",
-        "jackalope/jackalope": "dev-phpunit-9@dev"
+        "phpcr/phpcr-utils": "^1.5.0",
+        "jackalope/jackalope": "^1.4.2"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.3.0"
     },
     "require-dev": {
         "psr/log": "^1.0",
-        "phpcr/phpcr-api-tests": "dev-allow-php8@dev",
-        "phpunit/phpunit": "^7.5.18 || ^8.0 || ^9.0",
-        "phpunit/dbunit": "^4.0"
+        "phpcr/phpcr-api-tests": "2.1.22",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
+        "files": [ "src/dbal2_compat.php" ],
         "psr-0": { "Jackalope\\": "src/" }
     },
     "autoload-dev": {

--- a/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
+++ b/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Jackalope\Transport\DoctrineDBAL\RepositorySchema;
 
@@ -100,19 +100,12 @@ EOT
                         if (true === $input->getOption('dump-sql')) {
                             $output->writeln($sql);
                         } else {
-                            $connection->exec($sql);
+                            $connection->executeStatement($sql);
                         }
                     }
                 } catch (TableNotFoundException $e) {
                     if (false === $input->getOption('force')) {
                         throw $e;
-                    }
-                    // remove this once we require Doctrine DBAL 2.5+
-                } catch (DBALException $e) {
-                    if (false === $input->getOption('force')) {
-                        throw $e;
-                    } else {
-                        $output->writeln($e->getMessage());
                     }
                 }
             }
@@ -121,7 +114,7 @@ EOT
                 if (true === $input->getOption('dump-sql')) {
                     $output->writeln($sql);
                 } else {
-                    $connection->exec($sql);
+                    $connection->executeStatement($sql);
                 }
             }
         } catch (PDOException $e) {

--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -38,9 +38,9 @@ class CachedClient extends Client
     {
         parent::__construct($factory, $conn);
 
-        $caches['meta'] = isset($caches['meta']) ? $caches['meta'] : new ArrayCache();
+        $caches['meta'] = $caches['meta'] ?? new ArrayCache();
         $this->caches = $caches;
-        $this->keySanitizer = function ($cacheKey) {
+        $this->keySanitizer = static function ($cacheKey) {
             return str_replace(' ', '_', $cacheKey);
         };
     }

--- a/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Transport\DoctrineDBAL;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
@@ -216,14 +217,16 @@ class RepositorySchema extends Schema
             throw new RepositoryException('Do not use RepositorySchema::reset when not instantiated with a connection');
         }
 
-        $this->connection->getWrappedConnection()->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
         foreach ($this->toDropSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            try {
+                $this->connection->executeStatement($sql);
+            } catch (Exception $exception) {
+                // do nothing
+            }
         }
 
-        $this->connection->getWrappedConnection()->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         foreach ($this->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
     }
 

--- a/src/dbal2_compat.php
+++ b/src/dbal2_compat.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+class_exists('Doctrine\DBAL\Platforms\MySQLPlatform') || class_exists('Doctrine\DBAL\Platforms\MySqlPlatform');

--- a/src/dbal2_compat.php
+++ b/src/dbal2_compat.php
@@ -1,3 +1,5 @@
 <?php declare(strict_types=1);
 
+// doctrine/dbal version 2 used the lowercase form. On case sensitive filesystems, this leads to autoloading not working
+// for PHP, class names are case insensitive.
 class_exists('Doctrine\DBAL\Platforms\MySQLPlatform') || class_exists('Doctrine\DBAL\Platforms\MySqlPlatform');

--- a/tests/Jackalope/Test/Fixture/XMLDocument.php
+++ b/tests/Jackalope/Test/Fixture/XMLDocument.php
@@ -13,6 +13,8 @@ use DOMNode;
  */
 abstract class XMLDocument extends DOMDocument
 {
+    use XMLDocumentTrait;
+
     /**
      * file path
      *
@@ -120,7 +122,7 @@ abstract class XMLDocument extends DOMDocument
      *
      * @return XMLDocument
      */
-    public function save($file = null)
+    private function doSave($file = null)
     {
         if (isset($file)) {
             $this->file = $file;

--- a/tests/Jackalope/Test/Fixture/XMLDocumentTrait.php
+++ b/tests/Jackalope/Test/Fixture/XMLDocumentTrait.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Jackalope\Test\Fixture;
+
+if (PHP_VERSION_ID >= 80000) {
+    trait XMLDocumentTrait
+    {
+        /**
+         * Dumps the internal XML tree back into a file.
+         */
+        public function save(string $filename = null, int $options = 0): XMLDocument
+        {
+            return $this->doSave($filename);
+        }
+    }
+} else {
+    trait XMLDocumentTrait
+    {
+        public function save($file = null)
+        {
+            return $this->doSave($file);
+        }
+    }
+}

--- a/tests/Jackalope/Test/Tester/Generic.php
+++ b/tests/Jackalope/Test/Tester/Generic.php
@@ -2,18 +2,17 @@
 
 namespace Jackalope\Test\Tester;
 
+use Doctrine\DBAL\Connection;
 use ImplementationLoader;
 use PHPCR\Test\FixtureLoaderInterface;
-use PHPUnit\DbUnit\AbstractTester;
-use PHPUnit\DbUnit\Database\Connection;
-use PHPUnit\DbUnit\DataSet\XmlDataSet;
+use function implode;
 
 /**
  * Generic tester class.
  *
  * @author  cryptocompress <cryptocompress@googlemail.com>
  */
-class Generic extends AbstractTester implements FixtureLoaderInterface
+class Generic implements FixtureLoaderInterface
 {
     /**
      * @var Connection
@@ -26,14 +25,17 @@ class Generic extends AbstractTester implements FixtureLoaderInterface
     protected $fixturePath;
 
     /**
+     * @var XmlDataSet
+     */
+    private $dataSet;
+
+    /**
      * Creates a new default database tester using the given connection.
      *
      * @param string $fixturePath
      */
     public function __construct(Connection $connection, $fixturePath)
     {
-        parent::__construct();
-
         $this->connection   = $connection;
         $this->fixturePath  = $fixturePath;
     }
@@ -51,32 +53,48 @@ class Generic extends AbstractTester implements FixtureLoaderInterface
     public function import($fixtureName, $workspace = null)
     {
         $fixture = $this->fixturePath . DIRECTORY_SEPARATOR . $fixtureName . '.xml';
-        $this->setDataSet(new XmlDataSet($fixture));
+        $this->dataSet = new XmlDataSet($fixture);
 
         if ($workspace) {
-            $dataSet = $this->getDataSet();
+            $dataSet = $this->dataSet;
 
             // TODO: ugly hack, since we only really ever load a 2nd fixture in combination with '10_Writing/copy.xml'
             $fixture = $this->fixturePath . DIRECTORY_SEPARATOR . '10_Writing/copy.xml';
-            $this->setDataSet(new XmlDataSet($fixture));
+            $this->dataSet = new XmlDataSet($fixture);
 
             $loader = ImplementationLoader::getInstance();
             $workspaceName = $loader->getOtherWorkspaceName();
 
-            $this->dataSet->getTable('phpcr_workspaces')->addRow(['name' => $workspaceName]);
+            $this->dataSet->addRow('phpcr_workspaces', ['name' => $workspaceName]);
 
             foreach (['phpcr_nodes', 'phpcr_binarydata'] as $tableName) {
-                $table = $dataSet->getTable($tableName);
-                $targetTable = $this->dataSet->getTable($tableName);
+                $table = $dataSet->getRows($tableName);
 
-                for ($i = 0; $i < $table->getRowCount(); $i++) {
-                    $row = $table->getRow($i);
+                foreach ($table as $row) {
                     $row['workspace_name'] = $workspaceName;
-                    $targetTable->addRow($row);
+                    $this->dataSet->addRow($tableName, $row);
                 }
             }
         }
 
         $this->onSetUp();
+    }
+
+    public function onSetUp(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        foreach ($this->dataSet->getTables() as $table) {
+            $this->connection->executeStatement($platform->getTruncateTableSQL($table->getName(), true));
+        }
+
+        foreach ($this->dataSet->getTables() as $table) {
+            foreach ($this->dataSet->getRows($table->getName()) as $row) {
+                $sql = 'INSERT INTO '.$platform->quoteIdentifier($table->getName()).
+                    ' ('.implode(',', array_keys($row)).') VALUES ('.
+                    implode(',', array_fill(0, count($row), '?')).')';
+
+                $this->connection->executeStatement($sql, array_values($row));
+            }
+        }
     }
 }

--- a/tests/Jackalope/Test/Tester/Mysql.php
+++ b/tests/Jackalope/Test/Tester/Mysql.php
@@ -12,10 +12,10 @@ class Mysql extends Generic
     public function onSetUp(): void
     {
         // mysql from version 5.5.7 does not like to truncate tables with foreign key references: http://bugs.mysql.com/bug.php?id=58788
-        $this->getConnection()->getConnection()->exec('SET foreign_key_checks = 0');
+        $this->getConnection()->executeStatement('SET foreign_key_checks = 0');
 
         parent::onSetUp();
 
-        $this->getConnection()->getConnection()->exec('SET foreign_key_checks = 1');
+        $this->getConnection()->executeStatement('SET foreign_key_checks = 1');
     }
 }

--- a/tests/Jackalope/Test/Tester/Pgsql.php
+++ b/tests/Jackalope/Test/Tester/Pgsql.php
@@ -2,10 +2,6 @@
 
 namespace Jackalope\Test\Tester;
 
-use PHPUnit\DbUnit\Database\Connection;
-use PHPUnit\DbUnit\Operation\Factory;
-use PHPUnit\DbUnit\Operation_Factory;
-
 /**
  * PostgreSQL specific tester class.
  *
@@ -13,22 +9,16 @@ use PHPUnit\DbUnit\Operation_Factory;
  */
 class Pgsql extends Generic
 {
-    public function __construct(Connection $connection, $fixturePath)
-    {
-        parent::__construct($connection, $fixturePath);
-
-        $this->setUpOperation = Factory::CLEAN_INSERT(true);
-    }
-
     public function onSetUp(): void
     {
         parent::onSetUp();
 
-        $pdo = $this->getConnection()->getConnection();
+        $result = $this->connection->executeQuery("SELECT table_name, column_name FROM information_schema.columns WHERE column_default LIKE 'nextval%';");
+
         // update next serial/autoincrement value to max
-        foreach ($pdo->query("SELECT table_name, column_name FROM information_schema.columns WHERE column_default LIKE 'nextval%';")->fetchAll(\PDO::FETCH_ASSOC) as $info) {
+        foreach ($result->fetchAllAssociative() as $info) {
             $query = "SELECT setval((SELECT pg_get_serial_sequence('" . $info['table_name'] . "', '" . $info['column_name'] . "') as sequence), (SELECT max(" . $info['column_name'] . ") FROM " . $info['table_name'] . "));";
-            $pdo->query($query);
+            $this->connection->executeStatement($query);
         }
     }
 }

--- a/tests/Jackalope/Test/Tester/XmlDataSet.php
+++ b/tests/Jackalope/Test/Tester/XmlDataSet.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types=1);
+
+namespace Jackalope\Test\Tester;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use InvalidArgumentException;
+use RuntimeException;
+use SimpleXMLElement;
+use function libxml_clear_errors;
+use function libxml_get_errors;
+use function libxml_use_internal_errors;
+
+class XmlDataSet
+{
+    /**
+     * @var array
+     */
+    protected $tables;
+
+    /**
+     * @var SimpleXMLElement
+     */
+    protected $xmlFileContents;
+
+    /**
+     * @var array
+     */
+    private $rows = [];
+
+    /**
+     * Creates a new dataset using the given tables.
+     *
+     * @param string $xmlFile
+     */
+    public function __construct($xmlFile)
+    {
+        if (!\is_file($xmlFile)) {
+            throw new InvalidArgumentException("Could not find xml file: $xmlFile");
+        }
+
+        $libxmlErrorReporting  = libxml_use_internal_errors(true);
+        $this->xmlFileContents = simplexml_load_string(file_get_contents($xmlFile), 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_PARSEHUGE);
+
+        if (!$this->xmlFileContents) {
+            $message = '';
+
+            foreach (libxml_get_errors() as $error) {
+                $message .= \print_r($error, true);
+            }
+
+            throw new RuntimeException($message);
+        }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($libxmlErrorReporting);
+
+        $tableColumns = [];
+        $tableValues  = [];
+
+        $this->getTableInfo($tableColumns, $tableValues);
+        $this->createTables($tableColumns, $tableValues);
+    }
+
+    /**
+     * @return Table[]
+     */
+    public function getTables(): array
+    {
+        return $this->tables;
+    }
+
+    public function getRows(string $tableName): array
+    {
+        return $this->rows[$tableName] ?? [];
+    }
+
+    public function addRow(string $tableName, array $values)
+    {
+        $this->rows[$tableName][] = $values;
+    }
+
+    protected function createTables(array &$tableColumns, array &$tableValues): void
+    {
+        foreach ($tableValues as $tableName => $values) {
+            $this->getOrCreateTable($tableName, $tableColumns[$tableName]);
+
+            foreach ($values as $value) {
+                $this->rows[$tableName][] = $value;
+            }
+        }
+    }
+
+    protected function getTableInfo(array &$tableColumns, array &$tableValues): void
+    {
+        if ($this->xmlFileContents->getName() !== 'dataset') {
+            throw new RuntimeException('The root element of an xml data set file must be called <dataset>');
+        }
+
+        foreach ($this->xmlFileContents->xpath('/dataset/table') as $tableElement) {
+            if (empty($tableElement['name'])) {
+                throw new RuntimeException('Table elements must include a name attribute specifying the table name.');
+            }
+
+            $tableName = (string) $tableElement['name'];
+
+            if (!isset($tableColumns[$tableName])) {
+                $tableColumns[$tableName] = [];
+            }
+
+            if (!isset($tableValues[$tableName])) {
+                $tableValues[$tableName] = [];
+            }
+
+            $tableInstanceColumns = [];
+
+            foreach ($tableElement->xpath('./column') as $columnElement) {
+                $columnName = (string) $columnElement;
+
+                if (empty($columnName)) {
+                    throw new RuntimeException("Missing <column> elements for table $tableName. Add one or more <column> elements to the <table> element.");
+                }
+
+                if (!\in_array($columnName, $tableColumns[$tableName], true)) {
+                    $tableColumns[$tableName][] = $columnName;
+                }
+
+                $tableInstanceColumns[] = $columnName;
+            }
+
+            foreach ($tableElement->xpath('./row') as $rowElement) {
+                $rowValues                 = [];
+                $index                     = 0;
+                $numOfTableInstanceColumns = \count($tableInstanceColumns);
+
+                foreach ($rowElement->children() as $columnValue) {
+                    if ($index >= $numOfTableInstanceColumns) {
+                        throw new RuntimeException("Row contains more values than the number of columns defined for table $tableName.");
+                    }
+
+                    switch ($columnValue->getName()) {
+                        case 'value':
+                            $rowValues[$tableInstanceColumns[$index]] = (string) $columnValue;
+                            $index++;
+
+                            break;
+                        case 'null':
+                            $rowValues[$tableInstanceColumns[$index]] = null;
+                            $index++;
+
+                            break;
+                        default:
+                            throw new RuntimeException('Unknown element ' . $columnValue->getName() . ' in a row element.');
+                    }
+                }
+
+                $tableValues[$tableName][] = $rowValues;
+            }
+        }
+    }
+
+    /**
+     * Returns the table with the matching name. If the table does not exist
+     * an empty one is created.
+     *
+     * @param mixed  $tableColumns
+     *
+     * @return Table
+     */
+    protected function getOrCreateTable(string $tableName, $tableColumns)
+    {
+        if (empty($this->tables[$tableName])) {
+            $table = new Table($tableName, array_map(static function (string $columnName): Column {
+                return new Column($columnName, Type::getType(Types::STRING));
+            }, $tableColumns), [ new Index('primary', [ $tableColumns[0] ], false, true) ]);
+
+            $this->tables[$tableName] = $table;
+        }
+
+        return $this->tables[$tableName];
+    }
+}

--- a/tests/Jackalope/Tools/Console/InitDoctrineDbalCommandTest.php
+++ b/tests/Jackalope/Tools/Console/InitDoctrineDbalCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Jackalope\Tools\Console\Command;
+namespace Jackalope\Tools\Console;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Jackalope\Tools\Console\Command\InitDoctrineDbalCommand;
 use Jackalope\Tools\Console\Helper\DoctrineDbalHelper;
 use PDOException;
 use PHPUnit\Framework\TestCase;
@@ -45,7 +46,7 @@ class InitDoctrineDbalCommandTest extends TestCase
         $this->connection = $this->createMock(Connection::class);
         $this->schemaManager = $this->createMock(AbstractSchemaManager::class);
 
-        $this->platform = $this->createMock(MySqlPlatform::class);
+        $this->platform = $this->createMock(MySQLPlatform::class);
 
         $this->connection
             ->method('getDatabasePlatform')
@@ -90,6 +91,7 @@ class InitDoctrineDbalCommandTest extends TestCase
         $args = array_merge([
             'command' => $command->getName(),
         ], $args);
+
         $this->assertEquals($status, $commandTester->execute($args));
 
         return $commandTester;
@@ -105,9 +107,8 @@ class InitDoctrineDbalCommandTest extends TestCase
 
         // Unfortunately PDO doesn't follow internals and uses a non integer error code, which cannot be manually created
         $this->connection
-            ->expects($this->any())
-            ->method('exec')
-            ->will($this->throwException(new MockPDOException('', '42S01')))
+            ->method('executeStatement')
+            ->will(self::throwException(new MockPDOException('', '42S01')))
         ;
 
         $this->executeCommand('jackalope:init:dbal', ['--force' => true, '--drop' => true], 1);

--- a/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/CachedClientTest.php
@@ -25,8 +25,7 @@ class CachedClientTest extends FunctionalTestCase
     public function testArrayObjectIsConvertedToArray()
     {
         $namespaces = $this->transport->getNamespaces();
-
-        $this->assertInternalType('array', $namespaces);
+        self::assertIsArray($namespaces);
     }
 
     /**
@@ -34,12 +33,15 @@ class CachedClientTest extends FunctionalTestCase
      */
     public function testDefaultKeySanitizer()
     {
+        $first = true;
         $this->cacheMock
-            ->expects($this->at(0))
             ->method('fetch')
-            ->with(
-                $this->equalTo('nodetypes:_a:0:{}')
-            );
+            ->with(self::callback(function ($arg) use (&$first) {
+                self::assertEquals($first ? 'nodetypes:_a:0:{}' : 'node_types', $arg);
+                $first = false;
+
+                return true;
+            }));
 
         /** @var CachedClient $cachedClient */
         $cachedClient = $this->transport;
@@ -55,12 +57,15 @@ class CachedClientTest extends FunctionalTestCase
             return strrev($cacheKey);
         });
 
+        $first = true;
         $this->cacheMock
-            ->expects($this->at(0))
             ->method('fetch')
-            ->with(
-                $this->equalTo('}{:0:a :sepytedon')
-            );
+            ->with(self::callback(function ($arg) use (&$first) {
+                self::assertEquals($first ? '}{:0:a :sepytedon' : 'sepyt_edon', $arg);
+                $first = false;
+
+                return true;
+            }));
 
         /** @var CachedClient $cachedClient */
         $cachedClient = $this->transport;

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -310,13 +310,13 @@ class ClientTest extends FunctionalTestCase
         $method = $class->getMethod('generateUuid');
         $method->setAccessible(true);
 
-        $this->assertInternalType('string', $method->invoke($this->transport));
+        self::assertIsString($method->invoke($this->transport));
 
         $this->transport->setUuidGenerator(function () {
             return 'like-a-uuid';
         });
 
-        $this->assertEquals('like-a-uuid', $method->invoke($this->transport));
+        self::assertEquals('like-a-uuid', $method->invoke($this->transport));
     }
 
     public function testMoveAndReplace()

--- a/tests/Jackalope/Transport/DoctrineDBAL/Query/QOMWalkerTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/Query/QOMWalkerTest.php
@@ -2,6 +2,8 @@
 
 namespace Jackalope\Transport\DoctrineDBAL\Query;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Jackalope\NodeType\NodeTypeManager;
 use Jackalope\Test\TestCase;
 use Jackalope\Query\QOM\Length;
@@ -67,7 +69,7 @@ class QOMWalkerTest extends TestCase
         ;
 
         $query = $this->factory->createQuery($this->factory->selector('nt:unstructured', 'nt:unstructured'), null, [], []);
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured')", $this->defaultColumns), $sql);
     }
@@ -86,7 +88,7 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND n0.path = '/'", $this->defaultColumns), $sql);
     }
@@ -94,7 +96,7 @@ class QOMWalkerTest extends TestCase
     public function testQueryWithPropertyComparisonConstraint(): void
     {
         $this->nodeTypeManager
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getSubtypes')
             ->willReturn([])
         ;
@@ -105,9 +107,10 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
 
-        $this->assertContains(
+        [, , $sql] = $this->walker->walkQOMQuery($query);
+
+        self::assertStringContainsString(
             '//sv:property[@sv:name="jcr:createdBy"]/sv:value',
             $sql
         );
@@ -116,7 +119,7 @@ class QOMWalkerTest extends TestCase
     public function testQueryWithPropertyComparisonConstraintNumericLiteral(): void
     {
         $this->nodeTypeManager
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getSubtypes')
             ->willReturn([])
         ;
@@ -127,9 +130,9 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [, , $sql] = $this->walker->walkQOMQuery($query);
 
-        $this->assertContains('> 100', $sql);
+        self::assertStringContainsString('> 100', $sql);
     }
 
     public function testQueryWithAndConstraint(): void
@@ -149,7 +152,7 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND (n0.path = '/' AND n0.path = '/')", $this->defaultColumns), $sql);
     }
@@ -171,7 +174,7 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND (n0.path = '/' OR n0.path = '/')", $this->defaultColumns), $sql);
     }
@@ -188,7 +191,7 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND NOT (n0.path = '/')", $this->defaultColumns), $sql);
     }
@@ -221,7 +224,7 @@ class QOMWalkerTest extends TestCase
             [],
             []
         );
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND n0.path $op '/'", $this->defaultColumns), $sql);
     }
@@ -237,7 +240,7 @@ class QOMWalkerTest extends TestCase
             []
         );
 
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(
             sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') ORDER BY n0.path ASC", $this->defaultColumns),
@@ -247,9 +250,9 @@ class QOMWalkerTest extends TestCase
 
     public function testQueryWithOrderings()
     {
-        $driver = $this->conn->getDriver()->getName();
+        $platform = $this->conn->getDatabasePlatform();
 
-        $this->nodeTypeManager->expects($this->once())->method('getSubtypes')->will($this->returnValue([]));
+        $this->nodeTypeManager->expects(self::once())->method('getSubtypes')->willReturn([]);
 
         $query = $this->factory->createQuery(
             $this->factory->selector('nt:unstructured', 'nt:unstructured'),
@@ -260,13 +263,13 @@ class QOMWalkerTest extends TestCase
 
         $res = $this->walker->walkQOMQuery($query);
 
-
-        switch ($driver) {
-            case 'pdo_pgsql':
+        switch ($platform) {
+            case ($platform instanceof PostgreSQL94Platform || $platform instanceof PostgreSqlPlatform):
                 $ordering =
                     "CAST((xpath('//sv:property[@sv:name=\"foobar\"]/sv:value[1]/text()', CAST(n0.numerical_props AS xml), ARRAY[ARRAY['sv', 'http://www.jcp.org/jcr/sv/1.0']]))[1]::text AS DECIMAL) ASC, " .
                    "(xpath('//sv:property[@sv:name=\"foobar\"]/sv:value[1]/text()', CAST(n0.props AS xml), ARRAY[ARRAY['sv', 'http://www.jcp.org/jcr/sv/1.0']]))[1]::text ASC";
                 break;
+
             default:
                 $ordering =
                     "CAST(EXTRACTVALUE(n0.numerical_props, '//sv:property[@sv:name=\"foobar\"]/sv:value[1]') AS DECIMAL) ASC, " .
@@ -274,7 +277,7 @@ class QOMWalkerTest extends TestCase
         }
 
 
-        $this->assertEquals(
+        self::assertEquals(
             sprintf(
                 implode(' ', [
                     "SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ?",
@@ -297,7 +300,7 @@ class QOMWalkerTest extends TestCase
             $this->factory->descendantNode('nt:unstructured', '/')
         );
 
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(
             sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND n0.path LIKE '/%%'", $this->defaultColumns),
@@ -309,7 +312,7 @@ class QOMWalkerTest extends TestCase
             $this->factory->descendantNode('nt:unstructured', '/some/node')
         );
 
-        list($selectors, $selectorAliases, $sql) = $this->walker->walkQOMQuery($query);
+        [$selectors, $selectorAliases, $sql] = $this->walker->walkQOMQuery($query);
 
         $this->assertEquals(
             sprintf("SELECT %s FROM phpcr_nodes n0 WHERE n0.workspace_name = ? AND n0.type IN ('nt:unstructured') AND n0.path LIKE '/some/node/%%'", $this->defaultColumns),
@@ -320,7 +323,14 @@ class QOMWalkerTest extends TestCase
     public function testWalkOperand()
     {
         $operand = new Length(new PropertyValue('foo', 'bar'));
-        $this->assertRegExp('/\/\/sv:property\[@sv:name="bar"\]\/sv:value\[1\]\/@length/', $this->walker->walkOperand($operand));
+        $pattern = '/\/\/sv:property\[@sv:name="bar"\]\/sv:value\[1\]\/@length/';
+        $value = $this->walker->walkOperand($operand);
+
+        if (method_exists(self::class, 'assertMatchesRegularExpression')) {
+            self::assertMatchesRegularExpression($pattern, $value);
+        } else {
+            self::assertRegExp($pattern, $value);
+        }
     }
 
     public function testDescendantQueryTrailingSlash()


### PR DESCRIPTION
I've finished the work started in `php8` branch adding support for dbal 3.

DBUnit has been removed from dependencies, and an `XMLDataSet` class simulating its functionalities has been added to the `Jackalope\Test\Tester` namespace.
To correctly handle BC breaks introduced in DBAL, the minimum version of `doctrine/dbal` has been raised to 2.11. Consequently the minimum PHP version now is 7.3.

Missing fetch mode are simulated via `array_*` functions to maintain the expected logic.