### PR TITLE
CachedClient: Intepret only FALSE as a cache miss

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -598,7 +598,7 @@ class CachedClient extends Client
         $cacheKey = "query: {$query->getStatement()}, {$query->getLimit()}, {$query->getOffset()}, {$query->getLanguage()}, ".$this->workspaceName;
         $cacheKey = $this->sanitizeKey($cacheKey);
 
-        if ($result = $this->caches['query']->fetch($cacheKey)) {
+        if (false !== ($result = $this->caches['query']->fetch($cacheKey))) {
             return $result;
         }
 


### PR DESCRIPTION
Hi. while exploring the possibility of using query cache in our project, we noticed that empty results were not interpreted as a cache hit. We added a stricter check (!== false) to make this possible.

This point is somewhat related to this issue: https://github.com/doctrine/DoctrinePHPCRBundle/pull/359