### PR TITLE
Improve performance for xml parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.7.0
+-----
+
+* Improve performance for xml parsing.
+
 1.6.1
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 1.7.0
 -----
 
-* Improve performance for xml parsing.
+* Improve performance for xml parsing by using the PHP ext-xml instead of ext-dom.
+  Jackalope\Transport\DoctrineDBALClient::mapPropertyFromElement is no longer called within the client. If you extended the client and call the method, things will still work as before, but it is recommended to refactor your code to use the XmlToPropsParser. If you overwrote the method behaviour, your changes will no longer happen because the method is not called anymore.
 
 1.6.1
 -----

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -69,6 +69,7 @@ use PHPCR\Util\QOM\Sql2ToQomQueryConverter;
 use PHPCR\Util\UUIDHelper;
 use PHPCR\Util\ValueConverter;
 use stdClass;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
  * Class to handle the communication between Jackalope and RDBMS via Doctrine DBAL.
@@ -1138,6 +1139,11 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     protected function mapPropertyFromElement(DOMElement $propertyNode, stdClass $data)
     {
+        @trigger_error(
+            sprintf('The "%s" method is deprecated since jackalope/jackalope-doctrine-dbal 1.7.', __METHOD__),
+            \E_USER_DEPRECATED
+        );
+
         $name = $propertyNode->getAttribute('sv:name');
 
         $values = [];

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -69,7 +69,6 @@ use PHPCR\Util\QOM\Sql2ToQomQueryConverter;
 use PHPCR\Util\UUIDHelper;
 use PHPCR\Util\ValueConverter;
 use stdClass;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
  * Class to handle the communication between Jackalope and RDBMS via Doctrine DBAL.

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
@@ -8,7 +8,7 @@ use PHPCR\Util\ValueConverter;
 /**
  * @internal
  */
-class XmlToPropsParser
+final class XmlToPropsParser
 {
     /**
      * @var string
@@ -23,7 +23,7 @@ class XmlToPropsParser
     /**
      * @var ValueConverter
      */
-    protected $valueConverter;
+    private $valueConverter;
 
     /**
      * @var string|null

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
@@ -53,12 +53,12 @@ class XmlToPropsParser
     /**
      * @var mixed
      */
-    private $currentValueData = null;
+    private $currentValueData = '';
 
     /**
      * @var mixed
      */
-    private $currentPropData = null;
+    private $currentPropData = '';
 
     /**
      * @var \stdClass
@@ -134,50 +134,16 @@ class XmlToPropsParser
             return;
         }
 
-        // it could be that there exist a sv:property node without a sv:value
-        // in this case the value is set on the property data
-        if ($name === 'SV:PROPERTY' && empty($this->currentValues)) {
-            $this->currentValueData = $this->currentPropData;
+        if ($name === 'SV:VALUE') {
+            $this->addCurrentValue($this->currentValueData);
+            $this->currentValueData = '';
         }
 
-        if ($this->currentValueData) {
-            switch ($this->lastPropertyType) {
-                case PropertyType::NAME:
-                case PropertyType::URI:
-                case PropertyType::WEAKREFERENCE:
-                case PropertyType::REFERENCE:
-                case PropertyType::PATH:
-                case PropertyType::DECIMAL:
-                case PropertyType::STRING:
-                    $this->currentValues[] = $this->currentValueData;
-                    break;
-                case PropertyType::BOOLEAN:
-                    $this->currentValues[] = (bool)$this->currentValueData;
-                    break;
-                case PropertyType::LONG:
-                    $this->currentValues[] = (int)$this->currentValueData;
-                    break;
-                case PropertyType::BINARY:
-                    $this->currentValues[] = (int)$this->currentValueData;
-                    break;
-                case PropertyType::DATE:
-                    $date = $this->currentValueData;
-                    if ($date) {
-                        $date = new \DateTime($date);
-                        $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-                        // Jackalope expects a string, might make sense to refactor to allow DateTime instances too
-                        $date = $this->valueConverter->convertType($date, PropertyType::STRING);
-                    }
-                    $this->currentValues[] = $date;
-                    break;
-                case PropertyType::DOUBLE:
-                    $this->currentValues[] = (double)$this->currentValueData;
-                    break;
-                default:
-                    throw new \InvalidArgumentException("Type with constant $this->lastPropertyType not found.");
-            }
-
-            $this->currentValueData = null;
+        // it could be that there exist a sv:property node without a sv:value
+        // in this case the value is set on the property data
+        if ($name === 'SV:PROPERTY' && empty($this->currentValues) && !$this->lastPropertyMultiValued) {
+            $this->addCurrentValue($this->currentPropData);
+            $this->currentPropData = '';
         }
 
         if ($name !== 'SV:PROPERTY') {
@@ -194,9 +160,9 @@ class XmlToPropsParser
                 break;
         }
 
-        $this->currentValueData = null;
-        $this->currentPropData = null;
         $this->currentValues = [];
+        $this->currentValueData = '';
+        $this->currentPropData = '';
         $this->lastPropertyName = null;
         $this->lastPropertyType = null;
         $this->lastPropertyMultiValued = null;
@@ -209,15 +175,54 @@ class XmlToPropsParser
         }
 
         if ($this->currentTag === 'SV:VALUE') {
-            $this->currentValueData = $data;
+            $this->currentValueData .= $data;
 
             return;
         }
 
         if ($this->currentTag === 'SV:PROPERTY') {
-            $this->currentPropData = $data;
+            $this->currentPropData .= $data;
 
             return;
+        }
+    }
+
+    private function addCurrentValue($value): void
+    {
+        switch ($this->lastPropertyType) {
+            case PropertyType::NAME:
+            case PropertyType::URI:
+            case PropertyType::WEAKREFERENCE:
+            case PropertyType::REFERENCE:
+            case PropertyType::PATH:
+            case PropertyType::DECIMAL:
+            case PropertyType::STRING:
+                $this->currentValues[] = (string)$value;
+                break;
+            case PropertyType::BOOLEAN:
+                $this->currentValues[] = (bool)$value;
+                break;
+            case PropertyType::LONG:
+                $this->currentValues[] = (int)$value;
+                break;
+            case PropertyType::BINARY:
+                $this->currentValues[] = (int)$value;
+                break;
+            case PropertyType::DATE:
+                $date = $value;
+                if ($date) {
+                    $date = new \DateTime($date);
+                    $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+                    // Jackalope expects a string, might make sense to refactor to allow DateTime instances too
+                    $date = $this->valueConverter->convertType($date, PropertyType::STRING);
+                }
+                $this->currentValues[] = $date;
+                break;
+            case PropertyType::DOUBLE:
+                $this->currentValues[] = (double)$value;
+                break;
+            default:
+                throw new \InvalidArgumentException("Type with constant $this->lastPropertyType not found.");
         }
     }
 }

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Jackalope\Transport\DoctrineDBAL\XmlParser;
+
+use PHPCR\PropertyType;
+use PHPCR\Util\ValueConverter;
+
+/**
+ * @internal
+ */
+class XmlToPropsParser
+{
+    /**
+     * @var string
+     */
+    private $xml;
+
+    /**
+     * @var string[]|null
+     */
+    private $propertyNames;
+
+    /**
+     * @var ValueConverter
+     */
+    protected $valueConverter;
+
+    /**
+     * @var string|null
+     */
+    private $lastPropertyName = null;
+
+    /**
+     * @var string|null
+     */
+    private $lastPropertyType = null;
+
+    /**
+     * @var string|null
+     */
+    private $lastPropertyMultiValued = null;
+
+    /**
+     * @var string|null
+     */
+    private $currentTag = null;
+
+    /**
+     * @var mixed[]
+     */
+    private $currentValues = [];
+
+    /**
+     * @var mixed
+     */
+    private $currentValue = null;
+
+    /**
+     * @var \stdClass
+     */
+    private $data;
+
+    /**
+     * @param string $xml
+     * @param string[] $columnNames
+     */
+    public function __construct(
+        string $xml,
+        ValueConverter $valueConverter,
+        array $propertyNames = null
+    ) {
+        $this->xml = $xml;
+        $this->propertyNames = $propertyNames;
+        $this->valueConverter = $valueConverter;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function parse(): \stdClass
+    {
+        $this->data = new \stdClass();
+
+        $parser = xml_parser_create();
+
+        xml_set_element_handler(
+            $parser,
+            [$this, 'startHandler'],
+            [$this, 'endHandler']
+        );
+
+        xml_set_character_data_handler($parser, [$this, 'dataHandler']);
+
+        xml_parse($parser, $this->xml, true);
+        xml_parser_free($parser);
+        // avoid memory leaks and unset the parser see: https://www.php.net/manual/de/function.xml-parser-free.php
+        unset($parser);
+
+        return $this->data;
+    }
+
+    /**
+     * @param \XmlParser $parser
+     * @param string $name
+     * @param mixed[] $attrs
+     */
+    private function startHandler($parser, $name, $attrs): void
+    {
+        $this->currentTag = $name;
+
+        if ($name !== 'SV:PROPERTY') {
+            return;
+        }
+
+        if ($this->propertyNames !== null && !\in_array($attrs['SV:NAME'], $this->propertyNames)) {
+            return;
+        }
+
+        $this->lastPropertyName = $attrs['SV:NAME'];
+        $this->lastPropertyType = PropertyType::valueFromName($attrs['SV:TYPE']);
+        $this->lastPropertyMultiValued = $attrs['SV:MULTI-VALUED'];
+    }
+
+    private function endHandler($parser, $name): void
+    {
+        $this->currentTag = null;
+
+        if ($name === 'SV:PROPERTY' && $this->lastPropertyName) {
+            switch ($this->lastPropertyType) {
+                case PropertyType::BINARY:
+                    $this->data->{':' . $this->lastPropertyName} = $this->lastPropertyMultiValued ? $this->currentValues : $this->currentValues[0];
+                    break;
+                default:
+                    $this->data->{$this->lastPropertyName} = $this->lastPropertyMultiValued ? $this->currentValues : $this->currentValues[0];
+                    $this->data->{':' . $this->lastPropertyName} = $this->lastPropertyType;
+                    break;
+            }
+
+            $this->currentValues = [];
+            $this->lastPropertyName = null;
+            $this->lastPropertyType = null;
+            $this->lastPropertyMultiValued = null;
+
+            return;
+        }
+
+        if ($name === 'SV:VALUE' && $this->lastPropertyName) {
+            switch ($this->lastPropertyType) {
+                case PropertyType::NAME:
+                case PropertyType::URI:
+                case PropertyType::WEAKREFERENCE:
+                case PropertyType::REFERENCE:
+                case PropertyType::PATH:
+                case PropertyType::DECIMAL:
+                case PropertyType::STRING:
+                    $this->currentValues[] = $this->currentValue;
+                    break;
+                case PropertyType::BOOLEAN:
+                    $this->currentValues[] = (bool)$this->currentValue;
+                    break;
+                case PropertyType::LONG:
+                    $this->currentValues[] = (int)$this->currentValue;
+                    break;
+                case PropertyType::BINARY:
+                    $this->currentValues[] = (int)$this->currentValue;
+                    break;
+                case PropertyType::DATE:
+                    $date = $this->currentValue;
+                    if ($date) {
+                        $date = new \DateTime($date);
+                        $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+                        // Jackalope expects a string, might make sense to refactor to allow DateTime instances too
+                        $date = $this->valueConverter->convertType($date, PropertyType::STRING);
+                    }
+                    $this->currentValues[] = $date;
+                    break;
+                case PropertyType::DOUBLE:
+                    $this->currentValues[] = (double)$this->currentValue;
+                    break;
+                default:
+                    throw new \InvalidArgumentException("Type with constant $this->lastPropertyType not found.");
+            }
+        }
+    }
+
+    private function dataHandler($parser, $data): void
+    {
+        if ($this->currentTag === 'SV:VALUE' && $this->lastPropertyName) {
+            $this->currentValue = $data;
+        }
+    }
+}

--- a/tests/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParserTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParserTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Jackalope\Transport\DoctrineDBAL\XmlParser;
+
+use Jackalope\Factory;
+use Jackalope\Test\TestCase;
+use PHPCR\Util\ValueConverter;
+
+class XmlToPropsParserTest extends TestCase
+{
+    /**
+     * @var ValueConverter
+     */
+    private $valueConverter;
+
+    protected function setUp(): void
+    {
+        $factory = new Factory();
+
+        $this->valueConverter = $factory->get(ValueConverter::class);
+    }
+
+    public function testParseWithoutProps(): void
+    {
+        $xml = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node
+	xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+	xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:jcr="http://www.jcp.org/jcr/1.0"
+	xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+	xmlns:rep="internal">
+	<sv:property sv:name="jcr:primaryType" sv:type="Name" sv:multi-valued="0">
+		<sv:value length="15">nt:unstructured</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:mixinTypes" sv:type="Name" sv:multi-valued="1">
+		<sv:value length="9">sulu:page</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:uuid" sv:type="String" sv:multi-valued="0">
+		<sv:value length="36">0804f0c3-5250-4c2f-9d7e-7d0c99103026</sv:value>
+	</sv:property>
+	<sv:property sv:name="i18n:en-title" sv:type="String" sv:multi-valued="0">
+		<sv:value length="8">My Title</sv:value>
+	</sv:property>
+</sv:node>
+EOT;
+
+        $xmlParser = $this->createXmlToPropsParser($xml);
+        $data = $xmlParser->parse();
+
+        $this->assertSame('nt:unstructured', $data->{'jcr:primaryType'});
+        $this->assertSame(['sulu:page'], $data->{'jcr:mixinTypes'});
+        $this->assertSame('0804f0c3-5250-4c2f-9d7e-7d0c99103026', $data->{'jcr:uuid'});
+        $this->assertSame('My Title', $data->{'i18n:en-title'});
+    }
+
+    public function testParseWithProps(): void
+    {
+        $xml = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node
+	xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+	xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:jcr="http://www.jcp.org/jcr/1.0"
+	xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+	xmlns:rep="internal">
+	<sv:property sv:name="jcr:primaryType" sv:type="Name" sv:multi-valued="0">
+		<sv:value length="15">nt:unstructured</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:mixinTypes" sv:type="Name" sv:multi-valued="1">
+		<sv:value length="9">sulu:page</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:uuid" sv:type="String" sv:multi-valued="0">
+		<sv:value length="36">0804f0c3-5250-4c2f-9d7e-7d0c99103026</sv:value>
+	</sv:property>
+	<sv:property sv:name="i18n:en-title" sv:type="String" sv:multi-valued="0">
+		<sv:value length="8">My Title</sv:value>
+	</sv:property>
+</sv:node>
+EOT;
+
+        $xmlParser = $this->createXmlToPropsParser($xml, ['jcr:uuid']);
+        $data = $xmlParser->parse();
+
+        $this->assertFalse(isset($data->{'jcr:primaryType'}));
+        $this->assertFalse(isset($data->{'jcr:mixinTypes'}));
+        $this->assertTrue(isset($data->{'jcr:uuid'}));
+        $this->assertFalse(isset($data->{'i18n:de-title'}));
+        $this->assertSame('0804f0c3-5250-4c2f-9d7e-7d0c99103026', $data->{'jcr:uuid'});
+    }
+
+    private function createXmlToPropsParser(string $xml, array $propNames = null): XmlToPropsParser
+    {
+        return new XmlToPropsParser(
+            $xml,
+            $this->valueConverter,
+            $propNames
+        );
+    }
+}

--- a/tests/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParserTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParserTest.php
@@ -116,13 +116,35 @@ EOT;
 </sv:node>
 EOT;
 
-        $xmlParser = $this->createXmlToPropsParser($xml);
+        $xmlParser = $this->createXmlToPropsParser($xml, ['block_1_ref', 'block_2_ref', 'block_3_ref', 'external_reference']);
         $data = $xmlParser->parse();
 
         $this->assertSame('1922ec03-b5ed-40cf-856c-ecfb8eac12e2', $data->{'block_1_ref'});
         $this->assertSame('94c9aefe-faaa-4896-816b-5bfc575681f0', $data->{'block_2_ref'});
         $this->assertSame('a8ae4420-095b-4045-8775-b731cbae2fe1', $data->{'block_3_ref'});
         $this->assertSame('842e61c0-09ab-42a9-87c0-308ccc90e6f6', $data->{'external_reference'});
+    }
+
+    public function testParseEncoding(): void
+    {
+        $xml = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node
+	xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+	xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:jcr="http://www.jcp.org/jcr/1.0"
+	xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+	xmlns:phpcr="http://www.jcp.org/jcr/phpcr/1.0"
+	xmlns:rep="internal">
+	<sv:property sv:name="ampersand" sv:type="String" sv:multi-valued="0"><sv:value length="13">foo &amp; bar&amp;baz</sv:value></sv:property>
+</sv:node>
+EOT;
+
+        $xmlParser = $this->createXmlToPropsParser($xml, ['ampersand']);
+        $data = $xmlParser->parse();
+
+        $this->assertSame('foo & bar&baz', $data->{'ampersand'});
     }
 
     private function createXmlToPropsParser(string $xml, array $propNames = null): XmlToPropsParser

--- a/tests/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParserTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParserTest.php
@@ -78,6 +78,7 @@ EOT;
 	<sv:property sv:name="i18n:en-title" sv:type="String" sv:multi-valued="0">
 		<sv:value length="8">My Title</sv:value>
 	</sv:property>
+	<sv:property sv:name="i18n:nl-published" sv:type="Date" sv:multi-valued="0"><sv:value length="29">2020-04-16T08:57:07.256+00:00</sv:value></sv:property>
 </sv:node>
 EOT;
 
@@ -89,6 +90,39 @@ EOT;
         $this->assertTrue(isset($data->{'jcr:uuid'}));
         $this->assertFalse(isset($data->{'i18n:de-title'}));
         $this->assertSame('0804f0c3-5250-4c2f-9d7e-7d0c99103026', $data->{'jcr:uuid'});
+    }
+
+    public function testParseWithoutSvValueNode(): void
+    {
+        $xml = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node
+	xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+	xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:jcr="http://www.jcp.org/jcr/1.0"
+	xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+	xmlns:phpcr="http://www.jcp.org/jcr/phpcr/1.0"
+	xmlns:rep="internal">
+	<sv:property sv:name="jcr:primaryType" sv:type="name" sv:multi-valued="0">
+		<sv:value length="15">nt:unstructured</sv:value>
+	</sv:property>
+	<sv:property sv:name="block_1_ref" sv:type="reference" sv:multi-valued="0">1922ec03-b5ed-40cf-856c-ecfb8eac12e2</sv:property>
+	<sv:property sv:name="block_2_ref" sv:type="reference" sv:multi-valued="0">94c9aefe-faaa-4896-816b-5bfc575681f0</sv:property>
+	<sv:property sv:name="block_3_ref" sv:type="weakreference" sv:multi-valued="0">a8ae4420-095b-4045-8775-b731cbae2fe1</sv:property>
+	<sv:property sv:name="external_reference" sv:type="reference" sv:multi-valued="0">
+		<sv:value length="36">842e61c0-09ab-42a9-87c0-308ccc90e6f6</sv:value>
+	</sv:property>
+</sv:node>
+EOT;
+
+        $xmlParser = $this->createXmlToPropsParser($xml);
+        $data = $xmlParser->parse();
+
+        $this->assertSame('1922ec03-b5ed-40cf-856c-ecfb8eac12e2', $data->{'block_1_ref'});
+        $this->assertSame('94c9aefe-faaa-4896-816b-5bfc575681f0', $data->{'block_2_ref'});
+        $this->assertSame('a8ae4420-095b-4045-8775-b731cbae2fe1', $data->{'block_3_ref'});
+        $this->assertSame('842e61c0-09ab-42a9-87c0-308ccc90e6f6', $data->{'external_reference'});
     }
 
     private function createXmlToPropsParser(string $xml, array $propNames = null): XmlToPropsParser


### PR DESCRIPTION
I currently did analyse the performance of @sulu in https://github.com/sulu/sulu/pull/6089 after some optimizations on our side most time is spend now in `xmlToColumns` see the following benchmark:

## Before

Response time ~1080ms

 - https://blackfire.io/profiles/af73cb80-e327-4d12-9e76-d729b7097b86/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()
 
#### Apache Bench Test:
 
 ```bash
ab -n 50 -c 1 -l http://localhost/my-uri
 ```
 
 <details>
 <summary>Result: Requests per second:    1.01 [#/sec] (mean)</summary>
 
 ```bash
 Server Software:        nginx/1.21.0
Server Hostname:        stern-nl.localhost
Server Port:            80

Document Path:          /my-uri
Document Length:        348158 bytes

Concurrency Level:      1
Time taken for tests:   67.569 seconds
Complete requests:      50
Failed requests:        0
Total transferred:      17429509 bytes
HTML transferred:       17407759 bytes
Requests per second:    0.74 [#/sec] (mean)
Time per request:       1351.384 [ms] (mean)
Time per request:       1351.384 [ms] (mean, across all concurrent requests)
Transfer rate:          251.90 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   974 1351 479.1   1156    3550
Waiting:      973 1344 474.9   1155    3548
Total:        974 1351 479.1   1156    3550

Percentage of the requests served within a certain time (ms)
  50%   1156
  66%   1399
  75%   1533
  80%   1590
  90%   1896
  95%   2427
  98%   3550
  99%   3550
 100%   3550 (longest request)
 ```
 
 </details>
 
<img width="626" alt="Bildschirmfoto 2021-06-01 um 01 36 17" src="https://user-images.githubusercontent.com/1698337/120249034-c9f46300-c279-11eb-84a4-89a7a858cf37.png">

 
## After

Response time ~580ms
 
#### Apache Bench Test:
 
 ```bash
ab -n 50 -c 1 -l http://localhost/my-uri
 ```
 
 <details>
 <summary>Result: Requests per second:    1.91 [#/sec] (mean)</summary>
 
 ```bash
Server Software:        nginx/1.21.0
Server Hostname:        stern-nl.localhost
Server Port:            80

Document Path:          /my-uri
Document Length:        348161 bytes

Concurrency Level:      1
Time taken for tests:   30.322 seconds
Complete requests:      50
Failed requests:        0
Total transferred:      17429472 bytes
HTML transferred:       17407722 bytes
Requests per second:    1.65 [#/sec] (mean)
Time per request:       606.450 [ms] (mean)
Time per request:       606.450 [ms] (mean, across all concurrent requests)
Transfer rate:          561.33 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   504  606  88.9    571     789
Waiting:      503  605  88.8    570     789
Total:        504  606  88.9    571     789

Percentage of the requests served within a certain time (ms)
  50%    571
  66%    676
  75%    693
  80%    700
  90%    729
  95%    774
  98%    789
  99%    789
 100%    789 (longest request)
 ```
 
 </details>

  - https://blackfire.io/profiles/30ffb1b2-540d-4a7b-8831-68d3fe6c4564/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()
 
<img width="626" alt="Bildschirmfoto 2021-06-01 um 01 35 43" src="https://user-images.githubusercontent.com/1698337/120249041-cfea4400-c279-11eb-9238-6aec0a881ae9.png">
 
----
 
 This PR tries to use an more efficient way of parsing the xml structure sadly in costs of readability of the code, hope I can get into a form which it would be still maintainable.
 
 The PR is not yet finished and I'm just experimenting here a little bit. The blackfire profiles seems currently not show the result I'm seeing in the response times, need to investigate here more time. Update added the apache bench benchmark results for better performance testing.