### PR TITLE
Improve performance when deleting a property

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1843,33 +1843,32 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->loadXML($xml);
+        $xpath = new DomXpath($dom);
 
         $found = false;
         $propertyName = PathHelper::getNodeName($path);
-        foreach ($dom->getElementsByTagNameNS('http://www.jcp.org/jcr/sv/1.0', 'property') as $propertyNode) {
-            if ($propertyName == $propertyNode->getAttribute('sv:name')) {
-                $found = true;
-                // would be nice to have the property object to ask for type
-                // but its in state deleted, would mean lots of refactoring
-                if ($propertyNode->hasAttribute('sv:type')) {
-                    $type = strtolower($propertyNode->getAttribute('sv:type'));
-                    if (in_array($type, ['reference', 'weakreference'])) {
-                        $table = $this->referenceTables['reference' === $type ? PropertyType::REFERENCE : PropertyType::WEAKREFERENCE];
-                        try {
-                            $query = "DELETE FROM $table WHERE source_id = ? AND source_property_name = ?";
-                            $this->getConnection()->executeUpdate($query, [$nodeId, $propertyName]);
-                        } catch (DBALException $e) {
-                            throw new RepositoryException(
-                                'Unexpected exception while cleaning up deleted nodes',
-                                $e->getCode(),
-                                $e
-                            );
-                        }
+        foreach ($xpath->query(sprintf('//*[@sv:name="%s"]', $propertyName)) as $propertyNode) {
+            $found = true;
+            // would be nice to have the property object to ask for type
+            // but its in state deleted, would mean lots of refactoring
+            if ($propertyNode->hasAttribute('sv:type')) {
+                $type = strtolower($propertyNode->getAttribute('sv:type'));
+                if (in_array($type, ['reference', 'weakreference'])) {
+                    $table = $this->referenceTables['reference' === $type ? PropertyType::REFERENCE : PropertyType::WEAKREFERENCE];
+                    try {
+                        $query = "DELETE FROM $table WHERE source_id = ? AND source_property_name = ?";
+                        $this->getConnection()->executeUpdate($query, [$nodeId, $propertyName]);
+                    } catch (DBALException $e) {
+                        throw new RepositoryException(
+                            'Unexpected exception while cleaning up deleted nodes',
+                            $e->getCode(),
+                            $e
+                        );
                     }
                 }
-                $propertyNode->parentNode->removeChild($propertyNode);
-                break;
             }
+
+            $propertyNode->parentNode->removeChild($propertyNode);
         }
 
         if (!$found) {


### PR DESCRIPTION
I have found another performance problem when we have big nodes (10000+ properties). Inside of the function `Client::deleteProperty` we spend most of the time when updates such nodes (with write, delete operations). 

<hr>

# Before

Spend in Method: 21.7s

Profile https://blackfire.io/profiles/28b1016c-b67b-4f2c-a0cc-9dca6349a963/graph

![image](https://user-images.githubusercontent.com/1464615/140070891-88f002ae-ce60-42b0-ab31-10921e2a6fbc.png)

# After

Spend in Method: 528ms

Profile https://blackfire.io/profiles/40b5060b-1888-49b0-8f5e-08d9c1cb12ac/graph

![image](https://user-images.githubusercontent.com/1464615/140071009-ca45652f-c727-4af4-9de3-8577e850739d.png)

<hr>

To avoid iterating over all the properties this PR uses XPath to load only the needed property.

As i have not changed anything at the logic there is no change in the tests required.
