### PR TITLE
Allow Doctrine Cache 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.2 || ^8.0",
         "ext-pdo": "*",
         "doctrine/dbal": "^2.11 || ^3.0",
-        "doctrine/cache": "^1.12",
+        "doctrine/cache": "^1.12 || ^2",
         "phpcr/phpcr": "~2.1.5",
         "phpcr/phpcr-utils": "^1.5.0",
         "jackalope/jackalope": "^1.4.2",
@@ -29,9 +29,10 @@
         "jackalope/jackalope-transport": "1.3.0"
     },
     "require-dev": {
-        "psr/log": "^1.0",
+        "psr/log": "^1 || ^2 || ^3",
         "phpcr/phpcr-api-tests": "2.1.22",
-        "phpunit/phpunit": "8.5.21"
+        "phpunit/phpunit": "8.5.21",
+        "symfony/cache": "^5.4 || ^6.2"
     },
     "autoload": {
         "files": [ "src/dbal2_compat.php" ],

--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -38,7 +38,14 @@ class CachedClient extends Client
     {
         parent::__construct($factory, $conn);
 
-        $caches['meta'] = $caches['meta'] ?? new ArrayCache();
+        if (!isset($caches['meta'])) {
+            if (!class_exists(ArrayCache::class)) {
+                throw new \RuntimeException('No meta cache has been configured. Please either configure the meta cache explicitly or downgrade doctrine/cache to version 1.');
+            }
+
+            $caches['meta'] = new ArrayCache();
+        }
+
         $this->caches = $caches;
         $this->keySanitizer = static function ($cacheKey) {
             return str_replace(' ', '_', $cacheKey);

--- a/tests/ImplementationLoader.php
+++ b/tests/ImplementationLoader.php
@@ -1,15 +1,15 @@
 <?php
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
-use Jackalope\Test\Tester\Generic;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Jackalope\Factory;
 use Jackalope\Repository;
 use Jackalope\RepositoryFactoryDoctrineDBAL;
 use Jackalope\Session;
+use Jackalope\Test\Tester\Generic;
 use Jackalope\Test\Tester\Mysql;
 use Jackalope\Test\Tester\Pgsql;
 use Jackalope\Transport\DoctrineDBAL\Client;
@@ -18,6 +18,7 @@ use PHPCR\RepositoryException;
 use PHPCR\SimpleCredentials;
 use PHPCR\Test\AbstractLoader;
 use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Implementation loader for jackalope-doctrine-dbal
@@ -126,7 +127,7 @@ class ImplementationLoader extends AbstractLoader
         } else {
             $caches = [];
             foreach (explode(',', $GLOBALS['data_caches']) as $key) {
-                $caches[$key] = new ArrayCache();
+                $caches[$key] = DoctrineProvider::wrap(new ArrayAdapter());
             }
         }
 


### PR DESCRIPTION
Doctrine Cache is not maintained anymore. Version 2 is a transitional package with PSR-6 wrappers.

This PR allows the installation of v2 and uses Symfony Cache as a cache implementation for tests. The one problem I could not solve easily is this fallback here:

https://github.com/jackalope/jackalope-doctrine-dbal/blob/7a17d5955c52cd3a80b9f6e0b98da360f838917d/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php#L41

I chose to throw an exception if the `meta` cache has not been configured and `ArrayCache` is not available.

In the long run, this package should probably transition to PSR-6 and abandon Doctrine Cache completely.