### PR TITLE
Fix query syntax to work on MySQL with ANSI_QUOTES enabled

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Query/QOMWalker.php
@@ -758,7 +758,7 @@ class QOMWalker
 
         if ($this->platform instanceof MySQLPlatform && '=' === $operator) {
             return sprintf(
-                '0 != FIND_IN_SET("%s", REPLACE(EXTRACTVALUE(%s.props, \'//sv:property[@sv:name=%s]/sv:value\'), " ", ","))',
+                "0 != FIND_IN_SET('%s', REPLACE(EXTRACTVALUE(%s.props, '//sv:property[@sv:name=%s]/sv:value'), ' ', ','))",
                 $literalOperand->getLiteralValue(),
                 $alias,
                 Xpath::escape($property)


### PR DESCRIPTION
If MySQL is configured with SQL mode `ANSI_QUOTES` (or `ANSI`) the double quotes character is considered to quote an identifier name (such as table name, column name, etc.) rather than a literal string.

There is one place in the code base (which this PR aims to fix) where double quotes are being generated as part of the query, and running such a query on a MySQL server with `ANSI_QUOTES` enabled leads to an SQL error because the value of `$literalOperand` is being treated as a column name.