### PR TITLE
Taking advantage of batching property deletes when updating nodes

### DIFF
--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1557,7 +1557,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         }
 
         // Doing the actual removal
-        foreach($nodesById as $nodeId => $pathsToDelete) {
+        foreach ($nodesById as $nodeId => $pathsToDelete) {
             $this->removePropertiesFromNode($nodeId, $pathsToDelete);
         }
     }
@@ -1589,7 +1589,6 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     /**
      * Removes a list of properties from a given node.
      *
-     * @param string|int $nodeId
      * @param array<string> $paths Path belonging to that node that should be deleted
      */
     private function removePropertiesFromNode(string|int $nodeId, array $paths): void
@@ -1609,7 +1608,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
                 $found = true;
                 // would be nice to have the property object to ask for type
                 // but its in state deleted, would mean lots of refactoring
-                if (!$propertyNode->hasAttribute('sv:type')) { continue; }
+                if (!$propertyNode->hasAttribute('sv:type')) {
+                    continue;
+                }
 
                 $type = strtolower($propertyNode->getAttribute('sv:type'));
                 if (in_array($type, ['reference', 'weakreference'])) {

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1541,7 +1541,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     {
         $this->assertLoggedIn();
 
-        // Building a table describing which properties need to be deleted from which nodes so that we only have to parse contents once
+        // Building a table describing which properties need to be deleted from which nodes so that we only have to parse contents of each node once
         $nodesById = [];
         foreach ($operations as $op) {
             $nodePath = PathHelper::getParentPath($op->srcPath);


### PR DESCRIPTION
## Why
Currently the implementation for deleting a list of properties is to iterate over them and treat every delete of a property separately. This is a real determent to the performance of PHPCR, especially with bigger nodes.

Example: I want do delete three properties from the same node in the database. **For every property** we want to delete this is what it does:
* Check if the user is logged in.
* Load the node (SELECT query)
* Parse the document for it
* Remove property from the XML
* Update the XML in the database (UPDATE query)

> Which in turn means if you want to delete two properties from the same node, then you have to query the database for the node twice and also parse the document twice.

## The solution
Instead of defining the batch delete as a list of single deletes why not have the single delete make a batch delete with one element.

This pull request extracts out the logic for deleting a property from a node and extends it that you can delete a list of properties on one node as well.

To illustrate this with the same example: This would be the steps the program takes:
* Check login status at the start of the delete process
* Load the node once (1 SELECT query)
* Parse the document for it once
* Remove all properties from the XML in one go
* Update the XML in the database (1 UPDATE query)

> This massively reduces the amount of parsing the document and the amount of reads and writes to the database.

## Drawbacks
The new "batching functionality" first creates a map of properties and nodes to delete. Creating this map takes more memory than the brute force approach before.

## Others
Maybe we could also backport this speed up the 1.x branch so that project which are currently using the jackalope doctrine adapter also get the speed up.