### PR TITLE
delete binary when property is deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ phpcr_tests.db-journal
 
 vendor/
 composer.lock
-
-/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 * Fixed: While it is allowed to call `Repository::login` with `null` credentials, there used to be an error. It now correctly works.
   If you use `jcr:createdBy` or `jcr:lastModifiedBy` in node types, those properties are not set if the credentials are `null`.
 * Improving the performance of `deleteProperties` (#421)
+* Deleting dangling binary references when a property is removed or the whole node with a binary property is deleted (#426) - See UPGRADE.md for the recommended database changes.
 
 1.x
 ===

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,12 @@ Upgrade
 - `cli-config.php.dist` has been renamed to `cli-config.dist.php` - if you automate usage of the cli
   config file, you will need to adjust.
 
+- We changed the database schema to cascade delete the binary data when a node is deleted. To
+  upgrade the schema, delete all dangling references and add the foreign key to the database:
+
+  `DELETE FROM phpcr_binarydata where node_id NOT IN (SELECT id FROM phpcr_nodes)`
+  `ALTER TABLE phpcr_binarydata ADD CONSTRAINT fk_nodes FOREIGN KEY (node_id) REFERENCES phpcr_nodes(id) ON DELETE CASCADE`
+
 1.5
 ---
 

--- a/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
+++ b/tests/Jackalope/Test/Fixture/DBUnitFixtureXML.php
@@ -43,6 +43,7 @@ class DBUnitFixtureXML extends XMLDocument
     public function __construct(string $file)
     {
         parent::__construct($file);
+        $this->dom->appendChild($this->dom->createComment(' This fixture is generated from the PHPCR fixtures. Do not edit manually '));
 
         $this->tables = [];
         $this->ids = [];
@@ -50,11 +51,10 @@ class DBUnitFixtureXML extends XMLDocument
         $this->expectedNodes = [];
     }
 
-    public function addDataset()
+    public function save()
     {
-        $this->dom->appendChild($this->dom->createElement('dataset'));
-
         // purge binary in case no binary properties are in fixture
+        // do this at the very end to make sure the binary table comes after the nodes table to avoid referencial integrity issues.
         $this->ensureTableExists('phpcr_binarydata', [
             'node_id',
             'property_name',
@@ -62,6 +62,13 @@ class DBUnitFixtureXML extends XMLDocument
             'idx',
             'data',
         ]);
+
+        return parent::save();
+    }
+
+    public function addDataset()
+    {
+        $this->dom->appendChild($this->dom->createElement('dataset'));
 
         return $this;
     }

--- a/tests/Jackalope/Test/FunctionalTestCase.php
+++ b/tests/Jackalope/Test/FunctionalTestCase.php
@@ -46,7 +46,7 @@ class FunctionalTestCase extends TestCase
 
     protected function loadFixtures(Connection $conn): void
     {
-        $options = ['disable_fks' => $conn->getDatabasePlatform() instanceof SqlitePlatform];
+        $options = ['disable_fk' => $conn->getDatabasePlatform() instanceof SqlitePlatform];
         $schema = new RepositorySchema($options, $conn);
         $tables = $schema->getTables();
 

--- a/tests/Jackalope/Test/TestCase.php
+++ b/tests/Jackalope/Test/TestCase.php
@@ -8,29 +8,27 @@ use Jackalope\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    /**
-     * @var Connection
-     */
-    protected $conn;
+    protected ?Connection $conn;
 
     protected function getConnection(): Connection
     {
-        if (null === $this->conn) {
-            // @TODO see https://github.com/jackalope/jackalope-doctrine-dbal/issues/48
-            global $dbConn;
-            $this->conn = $dbConn;
-
-            if (null === $this->conn) {
-                $this->conn = DriverManager::getConnection([
-                    'driver' => @$GLOBALS['phpcr.doctrine.dbal.driver'],
-                    'path' => @$GLOBALS['phpcr.doctrine.dbal.path'],
-                    'host' => @$GLOBALS['phpcr.doctrine.dbal.host'],
-                    'user' => @$GLOBALS['phpcr.doctrine.dbal.username'],
-                    'password' => @$GLOBALS['phpcr.doctrine.dbal.password'],
-                    'dbname' => @$GLOBALS['phpcr.doctrine.dbal.dbname'],
-                ]);
-            }
+        if (isset($this->conn)) {
+            return $this->conn;
         }
+        // see https://github.com/jackalope/jackalope-doctrine-dbal/issues/48
+        global $dbConn;
+        if ($this->conn = $dbConn) {
+            return $this->conn;
+        }
+
+        $this->conn = DriverManager::getConnection([
+            'driver' => @$GLOBALS['phpcr.doctrine.dbal.driver'],
+            'path' => @$GLOBALS['phpcr.doctrine.dbal.path'],
+            'host' => @$GLOBALS['phpcr.doctrine.dbal.host'],
+            'user' => @$GLOBALS['phpcr.doctrine.dbal.username'],
+            'password' => @$GLOBALS['phpcr.doctrine.dbal.password'],
+            'dbname' => @$GLOBALS['phpcr.doctrine.dbal.dbname'],
+        ]);
 
         return $this->conn;
     }

--- a/tests/Jackalope/Transport/DoctrineDBAL/DeleteCascadeTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/DeleteCascadeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jackalope\Transport\DoctrineDBAL;
+
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Jackalope\Test\FunctionalTestCase;
+use PHPCR\PropertyType;
+
+class DeleteCascadeTest extends FunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->conn->getDatabasePlatform() instanceof SqlitePlatform) {
+            $this->markTestSkipped('Foreign keys are not supported with sqlite');
+        }
+
+        $a = $this->session->getNode('/')->addNode('node-a');
+        $a->setProperty('data', 'foo', PropertyType::BINARY);
+        $this->session->save();
+    }
+
+    public function testRemoveProperty(): void
+    {
+        $binaryRows = $this->conn->executeQuery('SELECT * FROM phpcr_binarydata');
+        $this->assertSame(1, $binaryRows->rowCount());
+
+        $this->session->removeItem('/node-a/data');
+        $this->session->save();
+        $binaryRows = $this->conn->executeQuery('SELECT * FROM phpcr_binarydata');
+        $this->assertSame(0, $binaryRows->rowCount());
+    }
+
+    public function testRemovePropertyFromNode(): void
+    {
+        $a = $this->session->getNode('/node-a');
+        $binaryRows = $this->conn->executeQuery('SELECT * FROM phpcr_binarydata');
+        $this->assertSame(1, $binaryRows->rowCount());
+
+        $a->getProperty('data')->remove();
+        $this->session->save();
+        $binaryRows = $this->conn->executeQuery('SELECT * FROM phpcr_binarydata');
+        $this->assertSame(0, $binaryRows->rowCount());
+    }
+
+    public function testRemoveNode(): void
+    {
+        $a = $this->session->getNode('/node-a');
+        $binaryRows = $this->conn->executeQuery('SELECT * FROM phpcr_binarydata');
+        $this->assertSame(1, $binaryRows->rowCount());
+
+        $a->remove();
+        $this->session->save();
+        $binaryRows = $this->conn->executeQuery('SELECT * FROM phpcr_binarydata');
+        $this->assertSame(0, $binaryRows->rowCount());
+    }
+}

--- a/tests/Jackalope/Transport/DoctrineDBAL/PrefetchTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/PrefetchTest.php
@@ -6,8 +6,6 @@ use Jackalope\Test\FunctionalTestCase;
 
 class PrefetchTest extends FunctionalTestCase
 {
-    protected $conn;
-
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Jackalope\Transport\DoctrineDBAL\RepositorySchema;
 
 /* Make sure we get ALL infos from php */
@@ -43,7 +44,7 @@ $dbConn = DriverManager::getConnection([
 
 /* Recreate database schema */
 if (!getenv('JACKALOPE_NO_TEST_DB_INIT')) {
-    $options = ['disable_fks' => $dbConn->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform];
+    $options = ['disable_fk' => $dbConn->getDatabasePlatform() instanceof SqlitePlatform];
     $repositorySchema = new RepositorySchema($options, $dbConn);
     $repositorySchema->reset();
 }


### PR DESCRIPTION
fix #356

* cascade deletion of node table to binary table
* remove binary when property is removed (like we do for references)