### PR TITLE
Adding return types to commands

### DIFF
--- a/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
+++ b/src/Jackalope/Tools/Console/Command/InitDoctrineDbalCommand.php
@@ -31,7 +31,7 @@ class InitDoctrineDbalCommand extends Command
      * @throws CliInvalidArgumentException
      * @throws \PDOException
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('jackalope:init:dbal')


### PR DESCRIPTION
Not specifying that the `configure` function is `void` is deprecated.