### PR TITLE
Improve delete properties performance by replace DOMDocument with xml_parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 1.x
 ===
 
+1.11.0 (unreleased)
+-------------------
+
 * Improve delete properties performance by replace DOMDocument with xml_parse
 
 1.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 1.x
 ===
 
+* Improve delete properties performance by replace DOMDocument with xml_parse
+
 1.10.1
 ------
 

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -31,6 +31,7 @@ use Jackalope\Query\Query;
 use Jackalope\Transport\BaseTransport;
 use Jackalope\Transport\DoctrineDBAL\Query\QOMWalker;
 use Jackalope\Transport\DoctrineDBAL\XmlParser\XmlToPropsParser;
+use Jackalope\Transport\DoctrineDBAL\XmlPropsRemover\XmlPropsRemover;
 use Jackalope\Transport\MoveNodeOperation;
 use Jackalope\Transport\NodeTypeManagementInterface;
 use Jackalope\Transport\QueryInterface as QueryTransport;
@@ -1798,10 +1799,19 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     public function deleteProperties(array $operations)
     {
-        $this->assertLoggedIn();
-
+        $nodesByPath = [];
         foreach ($operations as $op) {
-            $this->deleteProperty($op->srcPath);
+            $nodePath = PathHelper::getParentPath($op->srcPath);
+            $propertyName = PathHelper::getNodeName($op->srcPath);
+            if (!array_key_exists($nodePath, $nodesByPath)) {
+                $nodesByPath[$nodePath] = [];
+            }
+            $nodesByPath[$nodePath][$propertyName] = $propertyName;
+        }
+
+        // Doing the actual removal
+        foreach ($nodesByPath as $nodePath => $propertiesToDelete) {
+            $this->removePropertiesFromNode($nodePath, $propertiesToDelete);
         }
 
         return true;
@@ -1827,53 +1837,47 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     protected function deleteProperty($path)
     {
-        $this->assertLoggedIn();
-
         $nodePath = PathHelper::getParentPath($path);
+        $propertyName = PathHelper::getNodeName($path);
+        $this->removePropertiesFromNode($nodePath, [$propertyName]);
+    }
+
+    /**
+     * Removes a list of properties from a given node.
+     *
+     * @param string $nodeId
+     * @param array<string> $paths Path belonging to that node that should be deleted
+     */
+    private function removePropertiesFromNode($nodePath, array $propertiesToDelete): void
+    {
+        $this->assertLoggedIn();
         $nodeId = $this->getSystemIdForNode($nodePath);
         if (!$nodeId) {
             // no we really don't know that path
-            throw new ItemNotFoundException("No item found at " . $path);
+            throw new ItemNotFoundException('No item found at ' . $nodePath);
         }
 
         $query = 'SELECT props FROM phpcr_nodes WHERE id = ?';
         $xml = $this->getConnection()->fetchOne($query, [$nodeId]);
 
-        $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->loadXML($xml);
-        $xpath = new DomXpath($dom);
+        $xmlPropsRemover = new XmlPropsRemover($xml, $propertiesToDelete);
+        [$xml, $references] = $xmlPropsRemover->removeProps();
 
-        $found = false;
-        $propertyName = PathHelper::getNodeName($path);
-        foreach ($xpath->query(sprintf('//*[@sv:name="%s"]', $propertyName)) as $propertyNode) {
-            $found = true;
-            // would be nice to have the property object to ask for type
-            // but its in state deleted, would mean lots of refactoring
-            if ($propertyNode->hasAttribute('sv:type')) {
-                $type = strtolower($propertyNode->getAttribute('sv:type'));
-                if (in_array($type, ['reference', 'weakreference'])) {
-                    $table = $this->referenceTables['reference' === $type ? PropertyType::REFERENCE : PropertyType::WEAKREFERENCE];
-                    try {
-                        $query = "DELETE FROM $table WHERE source_id = ? AND source_property_name = ?";
-                        $this->getConnection()->executeUpdate($query, [$nodeId, $propertyName]);
-                    } catch (DBALException $e) {
-                        throw new RepositoryException(
-                            'Unexpected exception while cleaning up deleted nodes',
-                            $e->getCode(),
-                            $e
-                        );
-                    }
+        foreach ($references as $type => $propertyNames) {
+            $table = $this->referenceTables['reference' === $type ? PropertyType::REFERENCE : PropertyType::WEAKREFERENCE];
+            foreach ($propertyNames as $propertyName) {
+                try {
+                    $query = "DELETE FROM $table WHERE source_id = ? AND source_property_name = ?";
+                    $this->getConnection()->executeUpdate($query, [$nodeId, $propertyName]);
+                } catch (DBALException $e) {
+                    throw new RepositoryException(
+                        'Unexpected exception while cleaning up deleted nodes',
+                        $e->getCode(),
+                        $e
+                    );
                 }
             }
-
-            $propertyNode->parentNode->removeChild($propertyNode);
         }
-
-        if (!$found) {
-            throw new ItemNotFoundException("Node $nodePath has no property $propertyName");
-        }
-
-        $xml = $dom->saveXML();
 
         $query = 'UPDATE phpcr_nodes SET props = ? WHERE id = ?';
         $params = [$xml, $nodeId];
@@ -1881,7 +1885,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         try {
             $this->getConnection()->executeUpdate($query, $params);
         } catch (DBALException $e) {
-            throw new RepositoryException("Unexpected exception while updating properties of $path", $e->getCode(), $e);
+            throw new RepositoryException("Unexpected exception while updating properties of $nodePath", $e->getCode(), $e);
         }
     }
 

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1409,6 +1409,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
 
         $nestedNodes = $this->getNodesData($rows);
         $node = array_shift($nestedNodes);
+
         foreach ($nestedNodes as $nestedPath => $nested) {
             $relativePath = PathHelper::relativizePath($nestedPath, $path);
             $this->nestNode($node, $nested, explode('/', $relativePath));

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1839,9 +1839,9 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
      */
     protected function deleteProperty($path)
     {
+        $this->assertLoggedIn();
         $nodePath = PathHelper::getParentPath($path);
         $propertyName = PathHelper::getNodeName($path);
-        $this->assertLoggedIn();
         $this->removePropertiesFromNode($nodePath, [$propertyName]);
     }
 

--- a/src/Jackalope/Transport/DoctrineDBAL/Client.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/Client.php
@@ -1811,6 +1811,7 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
         }
 
         // Doing the actual removal
+        $this->assertLoggedIn();
         foreach ($nodesByPath as $nodePath => $propertiesToDelete) {
             $this->removePropertiesFromNode($nodePath, $propertiesToDelete);
         }
@@ -1840,18 +1841,18 @@ class Client extends BaseTransport implements QueryTransport, WritingInterface, 
     {
         $nodePath = PathHelper::getParentPath($path);
         $propertyName = PathHelper::getNodeName($path);
+        $this->assertLoggedIn();
         $this->removePropertiesFromNode($nodePath, [$propertyName]);
     }
 
     /**
      * Removes a list of properties from a given node.
      *
-     * @param string $nodeId
-     * @param array<string> $paths Path belonging to that node that should be deleted
+     * @param string $nodePath
+     * @param array<string> $propertiesToDelete Path belonging to that node that should be deleted
      */
     private function removePropertiesFromNode($nodePath, array $propertiesToDelete): void
     {
-        $this->assertLoggedIn();
         $nodeId = $this->getSystemIdForNode($nodePath);
         if (!$nodeId) {
             // no we really don't know that path

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlParser/XmlToPropsParser.php
@@ -86,18 +86,18 @@ final class XmlToPropsParser
     {
         $this->data = new \stdClass();
 
-        $parser = xml_parser_create();
+        $parser = \xml_parser_create();
 
-        xml_set_element_handler(
+        \xml_set_element_handler(
             $parser,
             [$this, 'startHandler'],
             [$this, 'endHandler']
         );
 
-        xml_set_character_data_handler($parser, [$this, 'dataHandler']);
+        \xml_set_character_data_handler($parser, [$this, 'dataHandler']);
 
-        xml_parse($parser, $this->xml, true);
-        xml_parser_free($parser);
+        \xml_parse($parser, $this->xml, true);
+        \xml_parser_free($parser);
         // avoid memory leaks and unset the parser see: https://www.php.net/manual/de/function.xml-parser-free.php
         unset($parser);
 

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
@@ -101,18 +101,12 @@ class XmlPropsRemover
 
             if (\in_array($svName, $this->propertyNames)) {
                 $this->skipCurrentTag = true;
+                $svType = $attrs['SV:TYPE'];
 
-                if (\in_array($svName, $this->propertyNames)) {
-                    $this->skipCurrentTag = true;
-                    $svType = $attrs['SV:TYPE'];
-
-                    if ($svType === 'reference') {
-                        $this->references[] = $svName;
-                    } elseif ($svType === 'weakreference') {
-                        $this->weakReferences[] = $svName;
-                    }
-
-                    return;
+                if ($svType === 'reference') {
+                    $this->references[] = $svName;
+                } elseif ($svType === 'weakreference') {
+                    $this->weakReferences[] = $svName;
                 }
 
                 return;

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Jackalope\Transport\DoctrineDBAL\XmlPropsRemover;
+
+/**
+ * @internal
+ */
+class XmlPropsRemover
+{
+    /**
+     * @var string
+     */
+    private $xml;
+
+    /**
+     * @var string[]
+     */
+    private $propertyNames;
+
+    /**
+     * @var bool
+     */
+    private $skipCurrentTag = false;
+
+    /**
+     * @var string
+     */
+    private $newXml = '';
+
+    /**
+     * @var string
+     */
+    private $newStartTag = '';
+
+    private $weakReferences = [];
+
+    private $references = [];
+
+    public function __construct(string $xml, array $propertyNames)
+    {
+        $this->xml = $xml;
+        $this->propertyNames = $propertyNames;
+    }
+
+    /**
+     * @return array{
+     *     0: string,
+     *     1: array{
+     *         reference: string[],
+     *         weakreference: string[],
+     *     },
+     * }
+     */
+    public function removeProps(): array
+    {
+        $this->newXml = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
+        $this->references = [];
+        $this->weakReferences = [];
+        $this->newStartTag = '';
+        $this->skipCurrentTag = false;
+
+        $parser = \xml_parser_create();
+
+        \xml_set_element_handler(
+            $parser,
+            [$this, 'startHandler'],
+            [$this, 'endHandler']
+        );
+
+        \xml_set_character_data_handler($parser, [$this, 'dataHandler']);
+
+        \xml_parse($parser, $this->xml, true);
+        \xml_parser_free($parser);
+        // avoid memory leaks and unset the parser see: https://www.php.net/manual/de/function.xml-parser-free.php
+        unset($parser);
+
+        return [
+            $this->newXml . PHP_EOL,
+            [
+                'reference' => $this->references,
+                'weakreference' => $this->weakReferences,
+            ],
+        ];
+    }
+
+    /**
+     * @param \XmlParser $parser
+     * @param string $name
+     * @param mixed[] $attrs
+     */
+    private function startHandler($parser, $name, $attrs): void
+    {
+        if ($this->skipCurrentTag) {
+            return;
+        }
+
+        if ($name === 'SV:PROPERTY') {
+            $svName = $attrs['SV:NAME'];
+
+            if (\in_array($svName, $this->propertyNames)) {
+                $this->skipCurrentTag = true;
+
+                if (\in_array($svName, $this->propertyNames)) {
+                    $this->skipCurrentTag = true;
+                    $svType = $attrs['SV:TYPE'];
+
+                    if ($svType === 'reference') {
+                        $this->references[] = $svName;
+                    } elseif ($svType === 'weakreference') {
+                        $this->weakReferences[] = $svName;
+                    }
+
+                    return;
+                }
+
+                return;
+            }
+        }
+
+        $tag = '<' . \strtolower($name);
+        foreach ($attrs as $key => $value) {
+            $tag .= ' ' . \strtolower($key) . '="' . $value . '"'; // TODO escaping
+        }
+        $tag .= '>';
+
+        $this->newXml .= $this->newStartTag;
+        $this->newStartTag = $tag; // handling self closing tags in endHandler
+    }
+
+    private function endHandler($parser, $name): void
+    {
+        if ($name === 'SV:PROPERTY' && $this->skipCurrentTag) {
+            $this->skipCurrentTag = false;
+
+            return;
+        }
+
+        if ($this->skipCurrentTag) {
+            return;
+        }
+
+        if ($this->newStartTag) {
+            // if the tag is not rendered to newXml it can be a self closing tag
+            $this->newXml .= \substr($this->newStartTag, 0.0, -1) . '/>';
+            $this->newStartTag = '';
+
+            return;
+        }
+
+        $this->newXml .= '</' . \strtolower($name) . '>';
+    }
+
+    private function dataHandler($parser, $data): void
+    {
+        if ($this->skipCurrentTag) {
+            return;
+        }
+
+        if ($data !== '') {
+            $this->newXml .= $this->newStartTag; // none empty data means no self closing tag so render tag now
+            $this->newStartTag = '';
+            $this->newXml .= \htmlspecialchars($data, ENT_XML1);
+        }
+    }
+}

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
@@ -43,13 +43,15 @@ class XmlPropsRemover
     }
 
     /**
+     * @example [$xml, $references] = $xmlPropsRemover->removeProps($xml, $propertiesToDelete);
+     *
      * @return array{
      *     0: string,
      *     1: array{
      *         reference: string[],
      *         weakreference: string[],
      *     },
-     * }
+     * } An array with the new xml (0) and the references (1) which requires to be removed.
      */
     public function removeProps(): array
     {
@@ -143,7 +145,7 @@ class XmlPropsRemover
         }
 
         if ($this->newStartTag) {
-            // if the tag is not rendered to newXml it can be a self closing tag
+            // if the tag is not rendered to newXml it can be a self-closing tag
             $this->newXml .= \substr($this->newStartTag, 0.0, -1) . '/>';
             $this->newStartTag = '';
 
@@ -160,9 +162,9 @@ class XmlPropsRemover
         }
 
         if ($data !== '') {
-            $this->newXml .= $this->newStartTag; // none empty data means no self closing tag so render tag now
+            $this->newXml .= $this->newStartTag; // non-empty data means no self closing tag so render tag now
             $this->newStartTag = '';
-            $this->newXml .= htmlspecialchars($data, ENT_XML1, 'UTF-8');
+            $this->newXml .= \htmlspecialchars($data, ENT_XML1, 'UTF-8');
         }
     }
 }

--- a/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemover.php
@@ -119,7 +119,10 @@ class XmlPropsRemover
 
         $tag = '<' . \strtolower($name);
         foreach ($attrs as $key => $value) {
-            $tag .= ' ' . \strtolower($key) . '="' . $value . '"'; // TODO escaping
+            $tag .= ' ' . \strtolower($key) // there is no case key which requires escaping for performance reasons we avoid it so
+                . '="'
+                . \htmlspecialchars($value, ENT_COMPAT, 'UTF-8')
+                . '"';
         }
         $tag .= '>';
 
@@ -159,7 +162,7 @@ class XmlPropsRemover
         if ($data !== '') {
             $this->newXml .= $this->newStartTag; // none empty data means no self closing tag so render tag now
             $this->newStartTag = '';
-            $this->newXml .= \htmlspecialchars($data, ENT_XML1);
+            $this->newXml .= htmlspecialchars($data, ENT_XML1, 'UTF-8');
         }
     }
 }

--- a/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/ClientTest.php
@@ -12,6 +12,7 @@ use PDO;
 use PHPCR\PropertyType;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface;
 use PHPCR\Query\QueryInterface;
+use PHPCR\SimpleCredentials;
 use PHPCR\Util\NodeHelper;
 use PHPCR\Util\PathHelper;
 use PHPCR\Util\QOM\QueryBuilder;
@@ -238,6 +239,34 @@ class ClientTest extends FunctionalTestCase
         $this->session->save();
 
         $this->addToAssertionCount(1);
+    }
+
+    public function testDeleteProperties()
+    {
+        $root = $this->session->getNode('/');
+        $node = $root->addNode('delete-properties');
+        for ($i = 0; $i <= 1000; $i++) {
+            $node->setProperty('property-'.$i, 'value-'.$i);
+        }
+
+        $this->session->save();
+        $this->assertSame(1002, \count($node->getProperties()));
+
+        for ($i = 501; $i <= 1000; $i++) {
+            $node->setProperty('property-'.$i, null);
+        }
+
+        $this->session->save();
+        $this->session->refresh(false);
+        $node = $this->session->getNode('/delete-properties');
+
+        for ($i = 0; $i <= 1000; $i++) {
+            $this->assertSame(
+                $i < 501,
+                $node->hasProperty('property-'.$i),
+                'Unexpected result for property "property-'.$i.'"'
+            );
+        }
     }
 
     public function testPropertyLengthAttribute()

--- a/tests/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemoverTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemoverTest.php
@@ -27,6 +27,7 @@ class XmlPropsRemoverTest extends TestCase
 		<sv:value length="8">My Title</sv:value>
 	</sv:property>
 	<sv:property sv:name="ampersand" sv:type="String" sv:multi-valued="0"><sv:value length="13">foo &amp; bar&amp;baz</sv:value></sv:property>
+	<sv:property sv:name="äüö?ß&lt;&gt;''&quot;=&quot;test" sv:type="String" sv:multi-valued="0"><sv:value length="15">&lt;&gt;:&amp;|öäü"?"ß'='</sv:value></sv:property>
 	<sv:property sv:name="block_1_ref" sv:type="reference" sv:multi-valued="0">1922ec03-b5ed-40cf-856c-ecfb8eac12e2</sv:property>
 	<sv:property sv:name="block_2_ref" sv:type="reference" sv:multi-valued="0">94c9aefe-faaa-4896-816b-5bfc575681f0</sv:property>
 	<sv:property sv:name="block_3_ref" sv:type="weakreference" sv:multi-valued="0">a8ae4420-095b-4045-8775-b731cbae2fe1</sv:property>
@@ -44,6 +45,9 @@ EOT;
         ]);
         [$xml, $references] = $xmlPropsRemover->removeProps();
 
+        $this->assertStringContainsString('äüö?ß&lt;&gt;\'\'&quot;=&quot;test', $xml, 'Not correctly escaped special chars property name, after removing props.');
+        $this->assertStringContainsString('&lt;&gt;:&amp;|öäü"?"ß\'=\'', $xml, 'Not correctly escaped special chars property value, after removing props.');
+
         $xmlParser = $this->createXmlToPropsParser($xml);
         $data = $xmlParser->parse();
         $this->assertSame([
@@ -55,6 +59,8 @@ EOT;
             ':jcr:uuid' => 1,
             'ampersand' => 'foo & bar&baz',
             ':ampersand' => 1,
+            'äüö?ß<>\'\'"="test' => '<>:&|öäü"?"ß\'=\'',
+            ':äüö?ß<>\'\'"="test' => 1,
             'block_1_ref' => '1922ec03-b5ed-40cf-856c-ecfb8eac12e2',
             ':block_1_ref' => 9,
         ], (array) $data);

--- a/tests/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemoverTest.php
+++ b/tests/Jackalope/Transport/DoctrineDBAL/XmlPropsRemover/XmlPropsRemoverTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Jackalope\Transport\DoctrineDBAL\XmlPropsRemover;
+
+use Jackalope\Factory;
+use Jackalope\Test\TestCase;
+use Jackalope\Transport\DoctrineDBAL\XmlParser\XmlToPropsParser;
+use PHPCR\Util\ValueConverter;
+
+class XmlPropsRemoverTest extends TestCase
+{
+    public function testRemoveProps(): void
+    {
+        $xml = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sv="http://www.jcp.org/jcr/sv/1.0" xmlns:rep="internal">
+	<sv:property sv:name="jcr:primaryType" sv:type="Name" sv:multi-valued="0">
+		<sv:value length="15">nt:unstructured</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:mixinTypes" sv:type="Name" sv:multi-valued="1">
+		<sv:value length="9">sulu:page</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:uuid" sv:type="String" sv:multi-valued="0">
+		<sv:value length="36">0804f0c3-5250-4c2f-9d7e-7d0c99103026</sv:value>
+	</sv:property>
+	<sv:property sv:name="i18n:en-title" sv:type="String" sv:multi-valued="0">
+		<sv:value length="8">My Title</sv:value>
+	</sv:property>
+	<sv:property sv:name="ampersand" sv:type="String" sv:multi-valued="0"><sv:value length="13">foo &amp; bar&amp;baz</sv:value></sv:property>
+	<sv:property sv:name="block_1_ref" sv:type="reference" sv:multi-valued="0">1922ec03-b5ed-40cf-856c-ecfb8eac12e2</sv:property>
+	<sv:property sv:name="block_2_ref" sv:type="reference" sv:multi-valued="0">94c9aefe-faaa-4896-816b-5bfc575681f0</sv:property>
+	<sv:property sv:name="block_3_ref" sv:type="weakreference" sv:multi-valued="0">a8ae4420-095b-4045-8775-b731cbae2fe1</sv:property>
+	<sv:property sv:name="external_reference" sv:type="reference" sv:multi-valued="0">
+		<sv:value length="36">842e61c0-09ab-42a9-87c0-308ccc90e6f6</sv:value>
+	</sv:property>
+</sv:node>
+EOT;
+
+        $xmlPropsRemover = $this->createXmlPropsRemover($xml, [
+            'i18n:en-title',
+            'block_2_ref',
+            'block_3_ref',
+            'external_reference',
+        ]);
+        [$xml, $references] = $xmlPropsRemover->removeProps();
+
+        $xmlParser = $this->createXmlToPropsParser($xml);
+        $data = $xmlParser->parse();
+        $this->assertSame([
+            'jcr:primaryType' => 'nt:unstructured',
+            ':jcr:primaryType' => 7,
+            'jcr:mixinTypes' => ['sulu:page'],
+            ':jcr:mixinTypes' => 7,
+            'jcr:uuid' => '0804f0c3-5250-4c2f-9d7e-7d0c99103026',
+            ':jcr:uuid' => 1,
+            'ampersand' => 'foo & bar&baz',
+            ':ampersand' => 1,
+            'block_1_ref' => '1922ec03-b5ed-40cf-856c-ecfb8eac12e2',
+            ':block_1_ref' => 9,
+        ], (array) $data);
+        $this->assertSame([
+            'reference' => [
+                'block_2_ref',
+                'external_reference',
+            ],
+            'weakreference' => [
+                'block_3_ref',
+            ],
+        ], $references);
+    }
+
+    private function createXmlPropsRemover(string $xml, array $propNames = null): XmlPropsRemover
+    {
+        return new XmlPropsRemover(
+            $xml,
+            $propNames
+        );
+    }
+
+    private function createXmlToPropsParser(string $xml, array $propNames = null): XmlToPropsParser
+    {
+        $factory = new Factory();
+
+        $valueConverter = $factory->get(ValueConverter::class);
+
+        return new XmlToPropsParser(
+            $xml,
+            $valueConverter,
+            $propNames
+        );
+    }
+}


### PR DESCRIPTION
See also: https://github.com/jackalope/jackalope-doctrine-dbal/pull/423

----

Prototype Repository: https://github.com/alexander-schranz/jackalope-xml-delete-properties

# Jackalope Doctrine DBAL Analyse deletion of properties

The benchmark requires 2 files:

 - `var/props.xml` - the xml of the node where we want to remove properties (SELECT props FROM phpcr_nodes WHERE identifier = ?)
 - `var/props.csv` - the props names which we want remove from the given xml (per line one property name)

## Different commands:

```bash
php src/remover.php legacy
php src/remover.php single_dom_document
php src/remover.php single_dom_query
php src/remover.php single_dom_query_chunk
php src/remover.php xml_parse
```

## Results

### ~70000 properties (~12.5MB) remove ~1700 props

Run on a MacBook Pro (16", 2021) Apple M1 Pro 32 GB:

| Command                | Time   | Memory |
|------------------------|--------|--------|
| legacy                 | 6m 29s | 48 MB  |
| single_dom_document    | 2m 25s | 35 MB  |
| single_dom_query       | 1m 30s | 37 MB  |
| single_dom_query_chunk | 1m 29s | 35 MB  |
| xml_parse              | ~1s    | 35 MB  |

`legacy`: is the `1.9.0` version: https://github.com/jackalope/jackalope-doctrine-dbal/blob/f7b286f388e0d3a42497c29e597756d6e346fea5/src/Jackalope/Transport/DoctrineDBAL/Client.php#L1804
`single_dom_document`: should represent the state of `2.0.0-beta2` version after: https://github.com/jackalope/jackalope-doctrine-dbal/pull/423/files

**Blackfire**

I did not use Blackfire for benchmarking as it did show in past benchmark where `xml_parse`
can not be good profiled as having a lot of callback method being called via `xml_set_element_handler` and `xml_set_character_data_handler`.
So profiling takes more time as processing things as Blackfire need to log every method call.
Instead I depend on classic benchmarking via time() and memory_get_peak_usage(true) measures.

### Required changes for improvements

#### A: Group Properties

The most important thing is that we remove all properties at once instead of calling `saveXML` after each property removal.

For this we mostly would require first group all `deleteProperties` by its `node`:

```php
function groupByNode($deletePropertyPaths): array {
    $grouped = [];
    foreach ($deletePropertyPaths as $path) {
        $nodePath = PathHelper::getParentPath($path);
        $propertyName = PathHelper::getNodeName($path);

        $grouped[$nodePath][] = $propertyName;
    }

    return $grouped;
}
```

Then we load the single `node` remove all the properties and save the xml once via `saveXML`.

#### B: Grouped Reference delete queries

The `queries` to remove references should also be grouped and best a single query be send to delete the references
instead of one query per reference.

The queries are currently ignored in the benchmark as it is focused on XML manipulation.

#### C: Replace DOMDocument with xml_parse

DOMDocument is bad for performance and should be avoided.
The `xml_parse` as it allows us to streamed reading the xml and skip the properties which we want to remove.
The [`XmlPropsRemover`](src/XmlPropsRemover.php) is an example how this could be done.

#### D: TODO

 - [x] xml_parse escape attributes name correctly
 - [x] xml_parse escape attributes value correctly
 - [x] xml_parse data content correctly
 - [x] xml_parse add queries to remove references
 - [x] xml_parse make sure the output is the same as for DOMDocument
    - [x] self closing tags
    - [x] escape data

~~currently there is a little difference in the 2 printed xmls:~~

```
-rw-r--r--   1 staff  staff  11940901 22 Nov 23:38 removed_legacy.xml
-rw-r--r--   1 staff  staff  12002548 22 Nov 23:39 removed_xml_parse.xml
```

Update `xml_parse` variant now has the same output as the previous DOMDocument version:

```
-rw-r--r--   1 staff  staff  11940901 22 Nov 23:33 removed_legacy.xml
-rw-r--r--   1 staff  staff  11940901 23 Nov 00:18 removed_xml_parse.xml
-rw-r--r--   1 staff  staff  12009559 22 Nov 23:45 removed_legacy_pretty.xml
-rw-r--r--   1 staff  staff  12009559 23 Nov 00:18 removed_xml_parse_pretty.xml
```

----

TODO:

 - [x] Check Sulu compatibility https://github.com/sulu/sulu/pull/7210