### PR TITLE
add missing cache key sanitize call for uuid map of referenceable nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 1.x
 ===
 
+1.13.1
+------
+
+* Fixed cache key sanitize for UUID map of referenceable nodes.
+
 1.13.0
 ------
 

--- a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
+++ b/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php
@@ -112,6 +112,7 @@ class CachedClient extends Client
         if ($node->isNodeType('mix:referenceable')) {
             $uuid = $node->getIdentifier();
             $cacheKey = "nodes by uuid: $uuid, ".$this->workspaceName;
+            $cacheKey = $this->sanitizeKey($cacheKey);
             $this->caches['nodes']->delete($cacheKey);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/jackalope/jackalope-doctrine-dbal/issues/450 for 1.x by backporting https://github.com/jackalope/jackalope-doctrine-dbal/commit/8cddf1fe23bec02578845ab03b72f6451ebc34ff

rebased #454 on 1.x with fixed build
fix #454